### PR TITLE
Move extension methods namespace

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CustomHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CustomHeaderExtensions.cs
@@ -1,4 +1,6 @@
-namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders
 {
     /// <summary>
     /// Extension methods for adding a <see cref="CustomHeader" /> to a <see cref="HeaderPolicyCollection" />

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ServerHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ServerHeaderExtensions.cs
@@ -1,4 +1,6 @@
-namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders
 {
     /// <summary>
     /// Extension methods for adding a <see cref="ServerHeader" /> to a <see cref="HeaderPolicyCollection" />

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/StrictTransportSecurityHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/StrictTransportSecurityHeaderExtensions.cs
@@ -1,4 +1,6 @@
-namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders
 {
     /// <summary>
     /// Extension methods for adding a <see cref="StrictTransportSecurityHeader" /> to a <see cref="HeaderPolicyCollection" />

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XContentTypeOptionsHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XContentTypeOptionsHeaderExtensions.cs
@@ -1,4 +1,6 @@
-namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders
 {
     /// <summary>
     /// Extension methods for adding a <see cref="XContentTypeOptionsHeader" /> to a <see cref="HeaderPolicyCollection" />

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XFrameOptionsHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XFrameOptionsHeaderExtensions.cs
@@ -1,4 +1,6 @@
-namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders
 {
     /// <summary>
     /// Extension methods for adding a <see cref="XFrameOptionsHeader" /> to a <see cref="HeaderPolicyCollection" />

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XssProtectionHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XssProtectionHeaderExtensions.cs
@@ -1,4 +1,6 @@
-namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders
 {
     /// <summary>
     /// Extension methods for adding a <see cref="XssProtectionHeader" /> to a <see cref="HeaderPolicyCollection" />

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/project.json
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/project.json
@@ -1,8 +1,8 @@
 ﻿{
-    "version": "0.1.0",
+    "version": "0.1.1",
     "packOptions": {
         "owners": [ "Andrew Lock" ],
-        "licenseUrl": "https://github.com/andrewlock/NetEscapades.AspNetCore.SecurityHeaders/blob/master/LICENSE",
+        "licenseUrl": "https://raw.githubusercontent.com/andrewlock/NetEscapades.AspNetCore.SecurityHeaders/master/LICENSE",
         "projectUrl": "https://github.com/andrewlock/NetEscapades.AspNetCore.SecurityHeaders",
         "repository": {
             "type": "git",

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/project.json
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/project.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "NetEscapades.AspNetCore.SecurityHeaders": {
-            "version": "0.1.0",
+            "version": "0.1.1",
             "target": "project"
         },
         "SecurityHeadersMiddlewareWebSite": {

--- a/test/SecurityHeadersMiddlewareWebSite/project.json
+++ b/test/SecurityHeadersMiddlewareWebSite/project.json
@@ -4,11 +4,11 @@
   },
   "dependencies": {
     "NetEscapades.AspNetCore.SecurityHeaders": {
-        "version": "0.1.0",
+        "version": "0.1.1",
         "target": "project"
      },
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0"
   },
   "frameworks": {
     "net451": {},


### PR DESCRIPTION
The security header extension methods were previously in the `Infrastructure` namespace. That didn't make a lot of sense and meant discoverability of them was poor. 

The headers and base classes are still currently in Infrastructure, as generally they will not be needed, though are still public should anyone want to extend them

Closes #8