### PR TITLE
CSP headers and updated defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,7 @@ When you install the package, it should be added to your `.csproj`. Alternativel
 </Project>
 ```
 
-In order to use the security headers middleware, you must configure the services in the `ConfigureServices` call of `Startup`: 
-
-```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    services.AddSecurityHeaders();
-}
-```
-
-You can then add the middleware to your ASP.NET Core application by configuring it as part of your normal `Startup` pipeline. Note that the order of middleware matters, so to apply the headers to all requests it should be configured first in your pipeline.
+Simply add the middleware to your ASP.NET Core application by configuring it as part of your normal `Startup` pipeline. Note that the order of middleware matters, so to apply the headers to all requests it should be configured first in your pipeline.
 
 To use the default security headers for your application, add the middleware using:
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ A small package to allow adding security headers to ASP.NET Core websites
 
 ## Installing 
 
-Install using the [NetEscapades.AspNetCore.SecurityHeaders NuGet package](https://www.nuget.org/packages/NetEscapades.AspNetCore.SecurityHeaders):
+Install using the [NetEscapades.AspNetCore.SecurityHeaders NuGet package](https://www.nuget.org/packages/NetEscapades.AspNetCore.SecurityHeaders) from the Visual Studio Package Manager Console:
 
 ```
 PM> Install-Package NetEscapades.AspNetCore.SecurityHeaders
+```
+
+Or using the `dotnet` CLI
+
+```
+dotnet package add Install-Package NetEscapades.AspNetCore.SecurityHeaders
 ```
 
 ## Usage 
@@ -28,24 +34,46 @@ When you install the package, it should be added to your `.csproj`. Alternativel
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.4.1" />
+    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.5.0" />
   </ItemGroup>
   
 </Project>
 ```
 
-In order to use the CustomHeader middleware, you must configure the services in the `ConfigureServices` call of `Startup`: 
+In order to use the security headers middleware, you must configure the services in the `ConfigureServices` call of `Startup`: 
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddCustomHeaders();
+    services.AddSecurityHeaders();
 }
 ```
 
 You can then add the middleware to your ASP.NET Core application by configuring it as part of your normal `Startup` pipeline. Note that the order of middleware matters, so to apply the headers to all requests it should be configured first in your pipeline.
 
-To configure the middleware, you should create an instance of a `HeaderPolicyCollection` and add the required policies to it. There are helper methods for adding a number of security-focused header values to the collection, or you can alternatively add any header by using the `CustomHeader` type. For example, the following would set a number of security headers, and a custom header `X-My-Test-Header`. 
+To use the default security headers for your application, add the middleware using:
+
+```csharp
+public void Configure(IApplicationBuilder app)
+{
+    app.UseSecurityHeaders()
+    
+    // other middleware e.g. static files, MVC etc  
+}
+```
+
+This adds the following headers to all responses that pass through the middleware:
+
+* `X-Content-Type-Options: nosniff`
+* `Strict-Transport-Security: max-age=31536000; includeSubDomains` - _only applied to HTTPS responses_
+* `X-Frame-Options: Deny` - _only applied to `text/html` responses_
+* `X-XSS-Protection: 1; mode=block` - _only applied to `text/html` responses_
+* `Referrer-Policy: origin-when-cross-origin` - _only applied to `text/html` responses_
+* `Content-Security-Policy: object-src 'none'; form-action 'self'; frame-ancestors 'none'` - _only applied to `text/html` responses_
+
+## Customising the security headers added to reponses
+
+To customise the headers returned, you should create an instance of a `HeaderPolicyCollection` and add the required policies to it. There are helper methods for adding a number of security-focused header values to the collection, or you can alternatively add any header by using the `CustomHeader` type. For example, the following would set a number of security headers, and a custom header `X-My-Test-Header`. 
 
 ```csharp
 public void Configure(IApplicationBuilder app)
@@ -54,14 +82,20 @@ public void Configure(IApplicationBuilder app)
         .AddFrameOptionsDeny()
         .AddXssProtectionBlock()
         .AddContentTypeOptionsNoSniff()
-        .AddStrictTransportSecurityMaxAge(maxAge: 60 * 60 * 24 * 365) // maxage = one year in seconds
+        .AddStrictTransportSecurityMaxAgeIncludeSubDomains(maxAge: 60 * 60 * 24 * 365) // maxage = one year in seconds
         .AddReferrerPolicyOriginWhenCrossOrigin()
         .RemoveServerHeader()
+        .AddContentSecurityPolicy(builder =>
+        {
+            builder.AddObjectSrc().None();
+            builder.AddFormAction().Self();
+            builder.AddFrameAncestors().None();
+        });
         .AddCustomHeader("X-My-Test-Header", "Header value");
     
-    app.UseCustomHeadersMiddleware(policyCollection)
+    app.UseSecurityHeaders(policyCollection)
     
-    // other middleware e.g. logging, MVC etc  
+    // other middleware e.g. static files, MVC etc  
 }
 ```
 
@@ -74,9 +108,24 @@ public void Configure(IApplicationBuilder app)
         .AddDefaultSecurityHeaders()
         .AddCustomHeader("X-My-Test-Header", "Header value");
     
-    app.UseCustomHeadersMiddleware(policyCollection)
+    app.UseSecurityHeaders(policyCollection)
     
-    // other middleware e.g. logging, MVC etc  
+    // other middleware e.g. static files, MVC etc  
+}
+```
+
+If you want to use the default security headers, but change one specific header, you can simply add another header to the default collection. For example, the following uses the default headers, but changes the max-age on the `Strict-Transport-Security` header:
+
+```csharp
+public void Configure(IApplicationBuilder app)
+{
+    var policyCollection = new HeaderPolicyCollection()
+        .AddDefaultSecurityHeaders()
+        .AddStrictTransportSecurityMaxAgeIncludeSubDomains(maxAge: 63072000);
+    
+    app.UseSecurityHeaders(policyCollection)
+    
+    // other middleware e.g. static files, MVC etc  
 }
 ```
 
@@ -94,9 +143,107 @@ var host = new WebHostBuilder()
 
 In `Program.cs`, when constructing your app's `WebHostBuilder`, configure the `KestrelServerOptions` to prevent the `Server` tag being added.
 
+## AddContentSecurityPolicy
+
+The `Content-Security-Policy` (CSP) headder is a very powerful header that can protect your website from a wide range of attacks. However, it's also totally possible to create a CSP header that completely breaks your app. 
+
+The CSP has a dizzying array of options, only some of which are implemented in this project. Consequently, I highly recommend reading [this post by Scott Helme](https://scotthelme.co.uk/content-security-policy-an-introduction/), in which he discusses the impact of each "directive". I also highly recommend using the "report only" version of the header when you start. This won't break your site, but will report instances that it would be broken, by providing reports to a service such as report-uri.com.
+
+Set the header to report-only by using the `AddContentSecurityPolicyReportOnly()` extension. For example:
+
+
+```csharp
+public void Configure(IApplicationBuilder app)
+{
+    var policyCollection = new HeaderPolicyCollection()
+        .AddContentSecurityPolicyReportOnly(builder => // report-only 
+        {
+            // configure policies
+        }); 
+}
+```
+
+or by by passing `true` to the `AddContentSecurityPolicy` command
+
+```csharp
+public void Configure(IApplicationBuilder app)
+{
+    var policyCollection = new HeaderPolicyCollection()
+        .AddContentSecurityPolicy(builder =>
+        {
+            // configure policies
+        },
+        asReportOnly: true); // report-only 
+}
+```
+
+You configure your CSP policy when you configure your `HeaderPolicyCollection` in `Startup.Configure`. For example:
+
+```csharp
+public void Configure(IApplicationBuilder app)
+{
+    var policyCollection = new HeaderPolicyCollection()
+        .AddContentSecurityPolicy(builder =>
+        {
+            builder.AddUpgradeInsecureRequests() // upgrade-insecure-requests
+
+            builder.AddReportUri() // report-uri: https://report-uri.com
+                .To("https://report-uri.com");
+
+            builder.AddDefaultSrc() // default-src 'self' http://testUrl.com
+                .Self()
+                .From("http://testUrl.com");
+
+            builder.AddConnectSrc() // connect-src 'self' http://testUrl.com
+                .Self()
+                .From("http://testUrl.com");
+
+            builder.AddFontSrc() // font-src 'self'
+                .Self();
+
+            builder.AddObjectSrc() // object-src 'none'
+                .None();
+                
+            builder.AddFormAction() // form-action 'self'
+                .Self();
+                
+            builder.AddImgSrc() // img-src https:
+                .OverHttps();
+            
+            builder.AddScriptSrc() // script-src 'self'
+                .Self();
+            
+            builder.AddStyleSrc() // style-src 'self'
+                .Self();
+            
+            builder.AddMediaSrc() // media-src https:
+                .OverHttps();
+
+            builder.AddFrameAncestors() // frame-ancestors 'none'
+                .None();
+                
+            builder.AddFrameSource() // frame-src http://testUrl.com
+                .From("http://testUrl.com");
+            
+            // You can also add arbitrary extra directives: plugin-types application/x-shockwave-flash"
+            builder.AddCustomDirective("plugin-types", "application/x-shockwave-flash");
+            
+        });
+        .AddCustomHeader("X-My-Test-Header", "Header value");
+    
+    app.UseSecurityHeaders(policyCollection)
+    
+    // other middleware e.g. static files, MVC etc  
+}
+```
+
+
 ## Additional Resources
 * [ASP.NET Core Middleware Docs](https://docs.asp.net/en/latest/fundamentals/middleware.html)
 * [How to add default security headers in ASP.NET Core using custom middleware](http://andrewlock.net/adding-default-security-headers-in-asp-net-core/)
+* [Content Security Policy - An Introduction](https://scotthelme.co.uk/content-security-policy-an-introduction/) by Scott Helme
+* [Content Security Policy Reference](https://content-security-policy.com/)
+* [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) by Mozilla Developer Network
 
 > Note, Building on Travis is currently disabled, due to issues with the mono framework. For details, see
 > * http://stackoverflow.com/questions/42747722/building-vs-2017-msbuild-csproj-projects-with-mono-on-linux/42861338

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddleware.cs
@@ -89,16 +89,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
             var policy = _policy ?? await _policyProvider.GetPolicyAsync(context, _policyName);
             if (policy != null)
             {
-                context.Response.OnStarting(() =>
-                {
-                    var result = _service.EvaluatePolicy(context, policy);
-                    _service.ApplyResult(context.Response, result);
-#if NET451
-                    return Task.FromResult(true);
-#else
-                    return Task.CompletedTask;
-#endif
-                });
+                var result = _service.EvaluatePolicy(context, policy);
+                _service.ApplyResult(context.Response, result);
             }
 
             await _next(context);

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddleware.cs
@@ -88,8 +88,16 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
             var policy = _policy ?? await _policyProvider.GetPolicyAsync(context, _policyName);
             if (policy != null)
             {
-                var result = _service.EvaluatePolicy(context, policy);
-                _service.ApplyResult(context.Response, result);
+                context.Response.OnStarting(() =>
+                {
+                    var result = _service.EvaluatePolicy(context, policy);
+                    _service.ApplyResult(context.Response, result);
+#if NET451
+                    return Task.FromResult(true);
+#else
+                    return Task.CompletedTask;
+#endif
+                });
             }
 
             await _next(context);

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddleware.cs
@@ -7,6 +7,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
     /// <summary>
     /// An ASP.NET Core middleware for adding security headers.
     /// </summary>
+    [Obsolete("This class is obsolete, use SecurityHeadersMiddleware instead")]
     public class CustomHeadersMiddleware
     {
         private readonly RequestDelegate _next;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
@@ -18,45 +18,14 @@ namespace Microsoft.AspNetCore.Builder
         [Obsolete("This method has been renamed to UseSecurityHeaders")]
         public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app, string policyName)
         {
-            return app.UseSecurityHeaders(policyName);
-        }
-
-        /// <summary>
-        /// Adds middleware to your web application pipeline to automatically add security headers to requests
-        /// </summary>
-        /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
-        /// <param name="policies">A configured policy collection.</param>
-        /// <returns>The original app parameter</returns>
-        [Obsolete("This method has been renamed to UseSecurityHeaders")]
-        public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app, HeaderPolicyCollection policies)
-        {
-            return app.UseSecurityHeaders(policies);
-        }
-
-        /// <summary>
-        /// Adds middleware to your web application pipeline to automatically add security headers to requests
-        /// 
-        /// Adds a policy collection configured using the default security headers, as in <see cref="HeaderPolicyCollectionExtensions.AddDefaultSecurityHeaders"/>
-        /// </summary>
-        /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
-        /// <returns>The original app parameter</returns>
-        [Obsolete("This method has been renamed to UseSecurityHeaders")]
-        public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app)
-        {
-            return app.UseSecurityHeaders();
-        }
-        
-        /// <summary>
-        /// Adds middleware to your web application pipeline to automatically add security headers to requests
-        /// </summary>
-        /// <param name="app">The IApplicationBuilder passed to your Configure method</param>
-        /// <param name="policyName">The policy name of a configured policy.</param>
-        /// <returns>The original app parameter</returns>
-        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app, string policyName)
-        {
             if (app == null)
             {
                 throw new ArgumentNullException(nameof(app));
+            }
+
+            if (string.IsNullOrWhiteSpace(policyName))
+            {
+                throw new ArgumentNullException(nameof(policyName));
             }
 
             return app.UseMiddleware<CustomHeadersMiddleware>(policyName);
@@ -68,7 +37,8 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
         /// <param name="policies">A configured policy collection.</param>
         /// <returns>The original app parameter</returns>
-        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app, HeaderPolicyCollection policies)
+        [Obsolete("This method has been renamed to UseSecurityHeaders")]
+        public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app, HeaderPolicyCollection policies)
         {
             if (app == null)
             {
@@ -82,20 +52,6 @@ namespace Microsoft.AspNetCore.Builder
 
             return app.UseMiddleware<CustomHeadersMiddleware>(policies);
         }
-
-        /// <summary>
-        /// Adds middleware to your web application pipeline to automatically add security headers to requests
-        /// 
-        /// Adds a policy collection configured using the default security headers, as in <see cref="HeaderPolicyCollectionExtensions.AddDefaultSecurityHeaders"/>
-        /// </summary>
-        /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
-        /// <returns>The original app parameter</returns>
-        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app)
-        {
-            var policies = new HeaderPolicyCollection()
-                .AddDefaultSecurityHeaders();
-
-            return app.UseSecurityHeaders(policies);
-        }
+        
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
@@ -92,15 +92,10 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns>The original app parameter</returns>
         public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app)
         {
-            if (app == null)
-            {
-                throw new ArgumentNullException(nameof(app));
-            }
-
             var policies = new HeaderPolicyCollection()
                 .AddDefaultSecurityHeaders();
 
-            return app.UseMiddleware<CustomHeadersMiddleware>(policies);
+            return app.UseSecurityHeaders(policies);
         }
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
@@ -45,5 +45,25 @@ namespace Microsoft.AspNetCore.Builder
 
             return app.UseMiddleware<CustomHeadersMiddleware>(policies);
         }
+
+        /// <summary>
+        /// Adds middleware to your web application pipeline to automatically add security headers to requests
+        /// 
+        /// Adds a policy collection configured using the default security headers, as in <see cref="HeaderPolicyCollectionExtensions.AddDefaultSecurityHeaders"/>
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            var policies = new HeaderPolicyCollection()
+                .AddDefaultSecurityHeaders();
+
+            return app.UseMiddleware<CustomHeadersMiddleware>(policies);
+        }
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The IApplicationBuilder passed to your Configure method</param>
         /// <param name="policyName">The policy name of a configured policy.</param>
         /// <returns>The original app parameter</returns>
+        [Obsolete("This method has been renamed to UseSecurityHeaders")]
         public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app, string policyName)
         {
             if (app == null)
@@ -31,6 +32,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
         /// <param name="policies">A configured policy collection.</param>
         /// <returns>The original app parameter</returns>
+        [Obsolete("This method has been renamed to UseSecurityHeaders")]
         public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app, HeaderPolicyCollection policies)
         {
             if (app == null)
@@ -53,7 +55,65 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
         /// <returns>The original app parameter</returns>
+        [Obsolete("This method has been renamed to UseSecurityHeaders")]
         public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            var policies = new HeaderPolicyCollection()
+                .AddDefaultSecurityHeaders();
+
+            return app.UseMiddleware<CustomHeadersMiddleware>(policies);
+        }
+        
+        /// <summary>
+        /// Adds middleware to your web application pipeline to automatically add security headers to requests
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your Configure method</param>
+        /// <param name="policyName">The policy name of a configured policy.</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app, string policyName)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            return app.UseMiddleware<CustomHeadersMiddleware>(policyName);
+        }
+
+        /// <summary>
+        /// Adds middleware to your web application pipeline to automatically add security headers to requests
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
+        /// <param name="policies">A configured policy collection.</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app, HeaderPolicyCollection policies)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (policies == null)
+            {
+                throw new ArgumentNullException(nameof(policies));
+            }
+
+            return app.UseMiddleware<CustomHeadersMiddleware>(policies);
+        }
+
+        /// <summary>
+        /// Adds middleware to your web application pipeline to automatically add security headers to requests
+        /// 
+        /// Adds a policy collection configured using the default security headers, as in <see cref="HeaderPolicyCollectionExtensions.AddDefaultSecurityHeaders"/>
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app)
         {
             if (app == null)
             {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
@@ -18,12 +18,7 @@ namespace Microsoft.AspNetCore.Builder
         [Obsolete("This method has been renamed to UseSecurityHeaders")]
         public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app, string policyName)
         {
-            if (app == null)
-            {
-                throw new ArgumentNullException(nameof(app));
-            }
-
-            return app.UseMiddleware<CustomHeadersMiddleware>(policyName);
+            return app.UseSecurityHeaders(policyName);
         }
 
         /// <summary>
@@ -35,17 +30,7 @@ namespace Microsoft.AspNetCore.Builder
         [Obsolete("This method has been renamed to UseSecurityHeaders")]
         public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app, HeaderPolicyCollection policies)
         {
-            if (app == null)
-            {
-                throw new ArgumentNullException(nameof(app));
-            }
-
-            if (policies == null)
-            {
-                throw new ArgumentNullException(nameof(policies));
-            }
-
-            return app.UseMiddleware<CustomHeadersMiddleware>(policies);
+            return app.UseSecurityHeaders(policies);
         }
 
         /// <summary>
@@ -58,15 +43,7 @@ namespace Microsoft.AspNetCore.Builder
         [Obsolete("This method has been renamed to UseSecurityHeaders")]
         public static IApplicationBuilder UseCustomHeadersMiddleware(this IApplicationBuilder app)
         {
-            if (app == null)
-            {
-                throw new ArgumentNullException(nameof(app));
-            }
-
-            var policies = new HeaderPolicyCollection()
-                .AddDefaultSecurityHeaders();
-
-            return app.UseMiddleware<CustomHeadersMiddleware>(policies);
+            return app.UseSecurityHeaders();
         }
         
         /// <summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeaderMiddlewareExtensions.cs
@@ -23,11 +23,6 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(app));
             }
 
-            if (string.IsNullOrWhiteSpace(policyName))
-            {
-                throw new ArgumentNullException(nameof(policyName));
-            }
-
             return app.UseMiddleware<CustomHeadersMiddleware>(policyName);
         }
 
@@ -52,6 +47,5 @@ namespace Microsoft.AspNetCore.Builder
 
             return app.UseMiddleware<CustomHeadersMiddleware>(policies);
         }
-        
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeadersServiceCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeadersServiceCollectionExtensions.cs
@@ -14,30 +14,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-        [Obsolete("This method has been renamed to AddSecurityHeaders")]
+        [Obsolete("This method will be removed in a future version")]
         public static IServiceCollection AddCustomHeaders(this IServiceCollection services)
-        {
-            return services.AddSecurityHeaders();
-        }
-
-        /// <summary>
-        /// Adds security header services to the specified <see cref="IServiceCollection" />.
-        /// </summary>
-        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        /// <param name="setupAction">An <see cref="Action{SecurityHeadersOptions}"/> to configure the provided <see cref="CustomHeaderOptions"/>.</param>
-        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-        [Obsolete("This method has been renamed to AddSecurityHeaders")]
-        public static IServiceCollection AddCustomHeaders(this IServiceCollection services, Action<CustomHeaderOptions> setupAction)
-        {
-            return services.AddSecurityHeaders(setupAction);
-        }
-        
-        /// <summary>
-        /// Adds security header services to the specified <see cref="IServiceCollection" />.
-        /// </summary>
-        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-        public static IServiceCollection AddSecurityHeaders(this IServiceCollection services)
         {
             if (services == null)
             {
@@ -58,7 +36,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
         /// <param name="setupAction">An <see cref="Action{SecurityHeadersOptions}"/> to configure the provided <see cref="CustomHeaderOptions"/>.</param>
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-        public static IServiceCollection AddSecurityHeaders(this IServiceCollection services, Action<CustomHeaderOptions> setupAction)
+        [Obsolete("This method will be removed in a future version")]
+        public static IServiceCollection AddCustomHeaders(this IServiceCollection services, Action<CustomHeaderOptions> setupAction)
         {
             if (services == null)
             {
@@ -70,7 +49,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(setupAction));
             }
 
-            services.AddSecurityHeaders();
+            services.AddCustomHeaders();
             services.Configure(setupAction);
 
             return services;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeadersServiceCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/CustomHeadersServiceCollectionExtensions.cs
@@ -14,7 +14,30 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        [Obsolete("This method has been renamed to AddSecurityHeaders")]
         public static IServiceCollection AddCustomHeaders(this IServiceCollection services)
+        {
+            return services.AddSecurityHeaders();
+        }
+
+        /// <summary>
+        /// Adds security header services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <param name="setupAction">An <see cref="Action{SecurityHeadersOptions}"/> to configure the provided <see cref="CustomHeaderOptions"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        [Obsolete("This method has been renamed to AddSecurityHeaders")]
+        public static IServiceCollection AddCustomHeaders(this IServiceCollection services, Action<CustomHeaderOptions> setupAction)
+        {
+            return services.AddSecurityHeaders(setupAction);
+        }
+        
+        /// <summary>
+        /// Adds security header services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddSecurityHeaders(this IServiceCollection services)
         {
             if (services == null)
             {
@@ -35,7 +58,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
         /// <param name="setupAction">An <see cref="Action{SecurityHeadersOptions}"/> to configure the provided <see cref="CustomHeaderOptions"/>.</param>
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-        public static IServiceCollection AddCustomHeaders(this IServiceCollection services, Action<CustomHeaderOptions> setupAction)
+        public static IServiceCollection AddSecurityHeaders(this IServiceCollection services, Action<CustomHeaderOptions> setupAction)
         {
             if (services == null)
             {
@@ -47,7 +70,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(setupAction));
             }
 
-            services.AddCustomHeaders();
+            services.AddSecurityHeaders();
             services.Configure(setupAction);
 
             return services;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
@@ -32,6 +32,12 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
             policies.AddStrictTransportSecurityMaxAge();
             policies.AddReferrerPolicyOriginWhenCrossOrigin();
             policies.RemoveServerHeader();
+            policies.AddContentSecurityPolicy(builder =>
+            {
+                builder.AddObjectSrc().None();
+                builder.AddFormAction().Self();
+                builder.AddFrameAncestors().None();
+            });
             return policies;
         }
     }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ConnectSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ConnectSourceDirectiveBuilder.cs
@@ -1,0 +1,13 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The connect-src directive restricts the URLs which can be loaded using script interfaces
+    /// The APIs that are restricted are:  &lt;a&gt; ping, Fetch, XMLHttpRequest, WebSocket, and EventSource.
+    /// </summary>
+    public class ConnectSourceDirectiveBuilder : CspDirectiveBuilder
+    {
+        public ConnectSourceDirectiveBuilder() : base("connect-src")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspBuilder.cs
@@ -1,0 +1,113 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    public class CspBuilder
+    {
+        /// <summary>
+        /// The default-src directive serves as a fallback for the other CSP fetch directives.
+        /// Valid sources include 'self', 'unsafe-inline', 'unsafe-eval', 'none', scheme such as http:,
+        /// or internet hosts by name or IP address, as well as an optional URL scheme and/or port number. 
+        /// The site's address may include an optional leading wildcard (the asterisk character, '*'), and 
+        /// you may use a wildcard (again, '*') as the port number, indicating that all legal ports are valid for the source.
+        /// </summary>
+        public DefaultSourceDirectiveBuilder AddDefaultSrc() => AddDirective(new DefaultSourceDirectiveBuilder());
+
+        /// <summary>
+        /// The connect-src directive restricts the URLs which can be loaded using script interfaces
+        /// The APIs that are restricted are:  &lt;a&gt; ping, Fetch, XMLHttpRequest, WebSocket, and EventSource.
+        /// </summary>
+        public ConnectSourceDirectiveBuilder AddConnectSrc() => AddDirective(new ConnectSourceDirectiveBuilder());
+
+        /// <summary>
+        /// The font-src directive specifies valid sources for fonts loaded using @font-face.
+        /// </summary>
+        public FontSourceDirectiveBuilder AddFontSrc() => AddDirective(new FontSourceDirectiveBuilder());
+
+        /// <summary>
+        /// The object-src directive specifies valid sources for the &lt;object&gt;, &lt;embed&gt;, and &lt;applet&gt; elements
+        /// </summary>
+        public ObjectSourceDirectiveBuilder AddObjectSrc() => AddDirective(new ObjectSourceDirectiveBuilder());
+
+        /// <summary>
+        /// The form-action directive restricts the URLs which can be used as the target of a form submissions from a given context
+        /// </summary>
+        public FormActionDirectiveBuilder AddFormAction() => AddDirective(new FormActionDirectiveBuilder());
+
+        /// <summary>
+        /// The img-src directive specifies valid sources of images and favicons
+        /// </summary>
+        public ImageSourceDirectiveBuilder AddImgSrc() => AddDirective(new ImageSourceDirectiveBuilder());
+
+        /// <summary>
+        /// The script-src directive specifies valid sources for sources for JavaScript.
+        /// </summary>
+        public ScriptSourceDirectiveBuilder AddScriptSrc() => AddDirective(new ScriptSourceDirectiveBuilder());
+
+        /// <summary>
+        /// The style-src directive specifies valid sources for sources for stylesheets.
+        /// </summary>
+        public StyleSourceDirectiveBuilder AddStyleSrc() => AddDirective(new StyleSourceDirectiveBuilder());
+
+        /// <summary>
+        /// The media-src directive specifies valid sources for loading media using the &lt;audio&gt; and &lt;video&gt; elements
+        /// </summary>
+        public MediaSourceDirectiveBuilder AddMediaSrc() => AddDirective(new MediaSourceDirectiveBuilder());
+
+        /// <summary>
+        /// The frame-ancestors directive specifies valid parents that may embed a page using 
+        /// &lt;frame&gt;, &lt;iframe&gt;, &lt;object&gt;, &lt;embed&gt;, or &lt;applet&gt;.
+        /// Setting this directive to 'none' is similar to X-Frame-Options: DENY (which is also supported in older browers).
+        /// </summary>
+        public FrameAncestorsDirectiveBuilder AddFrameAncestors() => AddDirective(new FrameAncestorsDirectiveBuilder());
+
+        /// <summary>
+        /// The frame-src directive specifies valid sources for nested browsing contexts loading 
+        /// using elements such as  &lt;frame&gt; and  &lt;iframe&gt;
+        /// </summary>
+        public FrameSourceDirectiveBuilder AddFrameSource() => AddDirective(new FrameSourceDirectiveBuilder());
+
+        /// <summary>
+        /// The upgrade-insecure-requests directive instructs user agents to treat all of a 
+        /// site's insecure URLs (those served over HTTP) as though they have been 
+        /// replaced with secure URLs (those served over HTTPS). This directive is 
+        /// intended for web sites with large numbers of insecure legacy URLs that need to be rewritten.
+        /// </summary>
+        public UpgradeInsecureRequestsDirectiveBuilder AddUpgradeInsecureRequests() => AddDirective(new UpgradeInsecureRequestsDirectiveBuilder());
+
+        /// <summary>
+        /// The upgrade-insecure-requests directive instructs user agents to treat all of a 
+        /// site's insecure URLs (those served over HTTP) as though they have been 
+        /// replaced with secure URLs (those served over HTTPS). This directive is 
+        /// intended for web sites with large numbers of insecure legacy URLs that need to be rewritten.
+        /// </summary>
+        public ReportUriDirectiveBuilder AddReportUri() => AddDirective(new ReportUriDirectiveBuilder());
+
+        /// <summary>
+        /// Create a custom CSP directive for an un-implemented directive
+        /// </summary>
+        /// <param name="directive">The directive name, e.g. default-src</param>
+        public CustomDirective AddCustomDirective(string directive) => AddDirective(new CustomDirective(directive));
+
+        /// <summary>
+        /// Create a custom CSP directive for an un-implemented directive
+        /// </summary>
+        /// <param name="directive">The directive name, e.g. default-src</param>
+        /// <param name="value">The directive value</param>
+        public CustomDirective AddCustomDirective(string directive, string value) => AddDirective(new CustomDirective(directive, value));
+
+        private readonly Dictionary<string, CspDirectiveBuilderBase> _directives = new Dictionary<string, CspDirectiveBuilderBase>();
+        
+        private T AddDirective<T>(T directive) where T: CspDirectiveBuilderBase
+        {
+            _directives[directive.Directive] = directive;
+            return directive;
+        }
+
+        internal string Build()
+        {
+            return string.Join("; ", _directives.Values.Select(x => x.Build()).Where(x => !string.IsNullOrEmpty(x)));
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspDirectiveBuilder.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    public class CspDirectiveBuilder : CspDirectiveBuilderBase
+    {
+        public CspDirectiveBuilder(string directive) : base(directive) { }
+
+        public List<string> Sources { get; } = new List<string>();
+        public bool BlockResources { get; set; } = false;
+
+        internal override string Build()
+        {
+            if (BlockResources)
+            {
+                return GetPolicy("'none'");
+            }
+            return GetPolicy(string.Join(" ", Sources));
+        }
+
+        private string GetPolicy(string value)
+        {
+            if (string.IsNullOrEmpty(value)) { return string.Empty; }
+            return $"{Directive} {value}";
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspDirectiveBuilderBase.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspDirectiveBuilderBase.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    public abstract class CspDirectiveBuilderBase
+    {
+        public CspDirectiveBuilderBase(string directive)
+        {
+            Directive = directive;
+        }
+
+        internal string Directive { get; }
+        internal abstract string Build();
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspDirectiveBuilderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspDirectiveBuilderExtensions.cs
@@ -66,7 +66,7 @@
         /// <returns>The CSP builder for method chaining</returns>
         public static T OverHttps<T>(this T builder) where T: CspDirectiveBuilder
         {
-            builder.Sources.Add("'https'");
+            builder.Sources.Add("https:");
             return builder;
         }
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspDirectiveBuilderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspDirectiveBuilderExtensions.cs
@@ -1,0 +1,124 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    public static class CspDirectiveBuilderExtensions
+    { 
+        /// <summary>
+        /// Allow sources from the origin from which the protected document is being served, including the same URL scheme and port number
+        /// </summary>
+        /// <returns>The CSP builder for method chaining</returns>
+        public static T Self<T>(this T builder) where T: CspDirectiveBuilder
+        {
+            builder.Sources.Add("'self'");
+            return builder;
+        }
+
+        /// <summary>
+        /// Allows blob: URIs to be used as a content source
+        /// </summary>
+        /// <returns>The CSP builder for method chaining</returns>
+        public static T Blob<T>(this T builder) where T: CspDirectiveBuilder
+        {
+            builder.Sources.Add("blob:");
+            return builder;
+        }
+
+        /// <summary>
+        /// data: Allows data: URIs to be used as a content source. 
+        /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+        /// </summary>
+        /// <returns>The CSP builder for method chaining</returns>
+        public static T Data<T>(this T builder) where T: CspDirectiveBuilder
+        {
+            builder.Sources.Add("data:");
+            return builder;
+        }
+
+        /// <summary>
+        /// Block the resource (Refers to the empty set; that is, no URLs match)
+        /// </summary>
+        /// <returns>The CSP builder for method chaining</returns>
+        public static T None<T>(this T builder) where T: CspDirectiveBuilder
+        {
+            builder.BlockResources = true;
+            return builder;
+        }
+
+        /// <summary>
+        /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
+        /// </summary>
+        /// <param name="builder">The builder instance</param>
+        /// <param name="uri">The URI to allow.</param>
+        /// <returns>The CSP builder for method chaining</returns>
+        public static T From<T>(this T builder, string uri) where T: CspDirectiveBuilder
+        {
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                throw new System.ArgumentException("Uri may not be null or empty", nameof(uri));
+            }
+
+            builder.Sources.Add(uri);
+            return builder;
+        }
+
+        /// <summary>
+        /// Allow resources served over https
+        /// </summary>
+        /// <returns>The CSP builder for method chaining</returns>
+        public static T OverHttps<T>(this T builder) where T: CspDirectiveBuilder
+        {
+            builder.Sources.Add("'https'");
+            return builder;
+        }
+
+        /// <summary>
+        /// A sha256, sha384 or sha512 hash of scripts or styles. 
+        /// Allow sources that match the provided hash.
+        /// </summary>
+        /// <param name="builder">The builder instance</param>
+        /// <param name="algorithm">The hash algorithm - one of sha256, sha384 or sha512 </param>
+        /// <param name="hash">The hash for the source</param>
+        /// <returns>The CSP builder for method chaining</returns>
+        public static T WithHash<T>(this T builder, string algorithm, string hash) where T: CspDirectiveBuilder
+        {
+            //TODO: check hash algorithm is one of expected values
+            builder.Sources.Add($"'{algorithm}-{hash}'");
+            return builder;
+        }
+
+        /// <summary>
+        /// A sha256 hash of scripts or styles. 
+        /// Allow sources that match the provided hash.
+        /// </summary>
+        /// <param name="builder">The builder instance</param>
+        /// <param name="hash">The hash for the source</param>
+        /// <returns>The CSP builder for method chaining</returns>
+        public static T WithHash256<T>(this T builder, string hash) where T: CspDirectiveBuilder
+        {
+            return builder.WithHash("sha256", hash);
+        }
+
+        /// <summary>
+        /// A sha384 hash of scripts or styles. 
+        /// Allow sources that match the provided hash.
+        /// </summary>
+        /// <param name="builder">The builder instance</param>
+        /// <param name="hash">The hash for the source</param>
+        /// <returns>The CSP builder for method chaining</returns>
+        public static T WithHashSha384<T>(this T builder, string hash) where T: CspDirectiveBuilder
+        {
+            return builder.WithHash("sha384", hash);
+        }
+
+        /// <summary>
+        /// A sha512 hash of scripts or styles. 
+        /// Allow sources that match the provided hash.
+        /// </summary>
+        /// <param name="builder">The builder instance</param>
+        /// <param name="hash">The hash for the source</param>
+        /// <returns>The CSP builder for method chaining</returns>
+        public static T WithHashSha512<T>(this T builder, string hash) where T: CspDirectiveBuilder
+        {
+            return builder.WithHash("sha512", hash);
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CustomDirective.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CustomDirective.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// Create a custom CSP directive for an un-implemented directive
+    /// </summary>
+    public class CustomDirective : CspDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Create a custom CSP directive for an un-implemented directive
+        /// </summary>
+        /// <param name="directive">The directive name, e.g. default-src</param>
+        /// <param name="value">The directive value</param>
+        public CustomDirective(string directive, string value) : base(directive)
+        {
+            if (string.IsNullOrEmpty(directive)) { throw new ArgumentException($"{nameof(directive)} must not be null or empty", nameof(directive)); }
+            if (string.IsNullOrEmpty(value)) { throw new ArgumentException($"{nameof(value)} must not be null or empty", nameof(value)); }
+
+            Value = value;
+        }
+
+        /// <summary>
+        /// Create a custom CSP directive for an un-implemented directive
+        /// </summary>
+        /// <param name="directive">The directive name, e.g. default-src</param>
+        public CustomDirective(string directive) : base(directive)
+        {
+            if (string.IsNullOrEmpty(directive)) { throw new ArgumentException($"{nameof(directive)} must not be null or empty", nameof(directive)); }
+            Value = string.Empty;
+        }
+
+        public string Value { get; }
+
+        internal override string Build()
+        {
+            if (string.IsNullOrEmpty(Value))
+            {
+                return Directive;
+            }
+            return $"{Directive} {Value}";
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/DefaultSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/DefaultSourceDirectiveBuilder.cs
@@ -1,0 +1,16 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The default-src directive serves as a fallback for the other CSP fetch directives.
+    /// Valid sources include 'self', 'unsafe-inline', 'unsafe-eval', 'none', scheme such as http:,
+    /// or internet hosts by name or IP address, as well as an optional URL scheme and/or port number. 
+    /// The site's address may include an optional leading wildcard (the asterisk character, '*'), and 
+    /// you may use a wildcard (again, '*') as the port number, indicating that all legal ports are valid for the source.
+    /// </summary>
+    public class DefaultSourceDirectiveBuilder : CspDirectiveBuilder
+    {
+        public DefaultSourceDirectiveBuilder() : base("default-src")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FontSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FontSourceDirectiveBuilder.cs
@@ -1,0 +1,12 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The font-src directive specifies valid sources for fonts loaded using @font-face.
+    /// </summary>
+    public class FontSourceDirectiveBuilder : CspDirectiveBuilder
+    {
+        public FontSourceDirectiveBuilder() : base("font-src")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FormActionDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FormActionDirectiveBuilder.cs
@@ -1,0 +1,12 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The form-action directive restricts the URLs which can be used as the target of a form submissions from a given context
+    /// </summary>
+    public class FormActionDirectiveBuilder :CspDirectiveBuilder
+    {
+        public FormActionDirectiveBuilder(): base("form-action")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameAncestorsDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameAncestorsDirectiveBuilder.cs
@@ -1,0 +1,14 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The frame-ancestors directive specifies valid parents that may embed a page using 
+    /// &lt;frame&gt;, &lt;iframe&gt;, &lt;object&gt;, &lt;embed&gt;, or &lt;applet&gt;.
+    /// Setting this directive to 'none' is similar to X-Frame-Options: DENY (which is also supported in older browers).
+    /// </summary>
+    public class FrameAncestorsDirectiveBuilder : CspDirectiveBuilder
+    {
+        public FrameAncestorsDirectiveBuilder() : base("frame-ancestors")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameSourceDirectiveBuilder.cs
@@ -1,0 +1,13 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The frame-src directive specifies valid sources for nested browsing contexts loading 
+    /// using elements such as  &lt;frame&gt; and  &lt;iframe&gt;
+    /// </summary>
+    public class FrameSourceDirectiveBuilder : CspDirectiveBuilder
+    {
+        public FrameSourceDirectiveBuilder() : base("frame-src")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ImageSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ImageSourceDirectiveBuilder.cs
@@ -1,0 +1,12 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The img-src directive specifies valid sources of images and favicons
+    /// </summary>
+    public class ImageSourceDirectiveBuilder : CspDirectiveBuilder
+    {
+        public ImageSourceDirectiveBuilder() : base("img-src")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/MediaSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/MediaSourceDirectiveBuilder.cs
@@ -1,0 +1,12 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The media-src directive specifies valid sources for loading media using the &lt;audio&gt; and &lt;video&gt; elements
+    /// </summary>
+    public class MediaSourceDirectiveBuilder : CspDirectiveBuilder
+    {
+        public MediaSourceDirectiveBuilder() : base("media-src")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ObjectSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ObjectSourceDirectiveBuilder.cs
@@ -1,0 +1,12 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The object-src directive specifies valid sources for the &lt;object&gt;, &lt;embed&gt;, and &lt;applet&gt; elements
+    /// </summary>
+    public class ObjectSourceDirectiveBuilder : CspDirectiveBuilder
+    {
+        public ObjectSourceDirectiveBuilder() : base("object-src")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ReportUriDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ReportUriDirectiveBuilder.cs
@@ -1,0 +1,39 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+
+    /// <summary>
+    /// The report-uri directive instructs the user agent to report attempts to
+    /// violate the Content Security Policy. These violation reports consist of 
+    /// JSON documents sent via an HTTP POST request to the specified URI.
+    /// </summary>
+    public class ReportUriDirectiveBuilder : CspDirectiveBuilderBase
+    {
+        public ReportUriDirectiveBuilder() : base("report-uri"){}
+        internal override string Build()
+        {
+            if (string.IsNullOrEmpty(Uri))
+            {
+                // TODO warn they added a report uri but no uri
+                return string.Empty;
+            }
+            return $"{Directive} {Uri}";
+        }
+
+        private string Uri { get; set; }
+
+        /// <summary>
+        /// The Uri where to post the report.
+        /// </summary>
+        /// <param name="uri">The URI to post the report to.</param>
+        /// <returns>Nothing, as can't be chained</returns>
+        public CspDirectiveBuilderBase To(string uri)
+        {
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                throw new System.ArgumentException("Uri may not be null or empty", nameof(uri));
+            }
+            Uri = uri;
+            return this;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceDirectiveBuilder.cs
@@ -1,0 +1,14 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The script-src directive specifies valid sources for sources for JavaScript.
+    /// This includes not only URLs loaded directly into &lt;script&gt; elements, but also things
+    /// like inline script event handlers (onclick) and XSLT stylesheets which can trigger script execution.
+    /// </summary>
+    public class ScriptSourceDirectiveBuilder : CspDirectiveBuilder
+    {
+        public ScriptSourceDirectiveBuilder() : base("script-src")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
@@ -1,0 +1,12 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The style-src directive specifies valid sources for sources for stylesheets.
+    /// </summary>
+    public class StyleSourceDirectiveBuilder : CspDirectiveBuilder
+    {
+        public StyleSourceDirectiveBuilder() : base("style-src")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/UpgradeInsecureRequestsDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/UpgradeInsecureRequestsDirectiveBuilder.cs
@@ -1,0 +1,18 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The upgrade-insecure-requests directive instructs user agents to treat all of a 
+    /// site's insecure URLs (those served over HTTP) as though they have been 
+    /// replaced with secure URLs (those served over HTTPS). This directive is 
+    /// intended for web sites with large numbers of insecure legacy URLs that need to be rewritten.
+    /// </summary>
+    public class UpgradeInsecureRequestsDirectiveBuilder : CspDirectiveBuilderBase
+    {
+        public UpgradeInsecureRequestsDirectiveBuilder() : base("upgrade-insecure-requests") { }
+
+        internal override string Build()
+        {
+            return Directive;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeader.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// The header value to use for Content-SecurityHeader
+    /// </summary>
+    public class ContentSecurityPolicyHeader : HeaderPolicyBase
+    {
+        /// <inheritdoc />
+        public ContentSecurityPolicyHeader(string value) : base(value)
+        {
+            Value = value;
+        }
+
+        /// <inheritdoc />
+        public override string Header { get; } = "Content-Security-Policy";
+        
+        /// <summary>
+        /// Configure a content security policy
+        /// </summary>
+        /// <param name="configure">Configure the CSP</param>
+        /// <returns></returns>
+        public static ContentSecurityPolicyHeader Build(Action<CspBuilder> configure)
+        {
+            var builder = new CspBuilder();
+
+            configure(builder);
+
+            return new ContentSecurityPolicyHeader(builder.Build());
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeader.cs
@@ -7,27 +7,39 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
     /// </summary>
     public class ContentSecurityPolicyHeader : HeaderPolicyBase
     {
-        /// <inheritdoc />
-        public ContentSecurityPolicyHeader(string value) : base(value)
+        /// <summary>
+        /// Create a new policy
+        /// </summary>
+        /// <param name="asReportOnly">If true, the header is added as report only</param>
+        /// <param name="value">The value to apply for the header</param>
+        public ContentSecurityPolicyHeader(string value, bool asReportOnly) : base(value)
         {
             Value = value;
+            ReportOnly = asReportOnly;
         }
 
         /// <inheritdoc />
-        public override string Header { get; } = "Content-Security-Policy";
-        
+        public override string Header => ReportOnly? "Content-Security-Policy-Report-Only" : "Content-Security-Policy";
+
+        /// <summary>
+        /// If true, the CSP header is addded as "Content-Security-Policy-Report-Only".
+        /// If false, it's set to "Content-Security-Policy";
+        /// </summary>
+        public bool ReportOnly { get; }
+
         /// <summary>
         /// Configure a content security policy
         /// </summary>
         /// <param name="configure">Configure the CSP</param>
+        /// <param name="asReportOnly">If true, the header is added as report only</param>
         /// <returns></returns>
-        public static ContentSecurityPolicyHeader Build(Action<CspBuilder> configure)
+        public static ContentSecurityPolicyHeader Build(Action<CspBuilder> configure, bool asReportOnly)
         {
             var builder = new CspBuilder();
 
             configure(builder);
 
-            return new ContentSecurityPolicyHeader(builder.Build());
+            return new ContentSecurityPolicyHeader(builder.Build(), asReportOnly);
         }
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeader.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using Microsoft.AspNetCore.Http;
 
 namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
 {
     /// <summary>
     /// The header value to use for Content-SecurityHeader
     /// </summary>
-    public class ContentSecurityPolicyHeader : HeaderPolicyBase
+    public class ContentSecurityPolicyHeader : HtmlOnlyHeaderPolicyBase
     {
         /// <summary>
         /// Create a new policy

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeaderExtensions.cs
@@ -13,9 +13,10 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         /// </summary>
         /// <param name="policies">The collection of policies</param>
         /// <param name="configure">Configure the CSP</param>
-        public static HeaderPolicyCollection AddContentSecurityPolicy(this HeaderPolicyCollection policies, Action<CspBuilder> configure)
+        /// <param name="asReportOnly">If true, the CSP header is addded as "Content-Security-Policy-Report-Only". If false, it's set to "Content-Security-Policy";</param>
+        public static HeaderPolicyCollection AddContentSecurityPolicy(this HeaderPolicyCollection policies, Action<CspBuilder> configure, bool asReportOnly = false)
         {
-            return policies.ApplyPolicy(ContentSecurityPolicyHeader.Build(configure));
+            return policies.ApplyPolicy(ContentSecurityPolicyHeader.Build(configure, asReportOnly));
         }
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeaderExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders
+{
+    /// <summary>
+    /// Extension methods for adding a <see cref="ContentSecurityPolicyHeader" /> to a <see cref="HeaderPolicyCollection" />
+    /// </summary>
+    public static class ContentSecurityPolicyHeaderExtensions
+    {
+        /// <summary>
+        /// Add a Content-Security-Header to all requests
+        /// </summary>
+        /// <param name="policies">The collection of policies</param>
+        /// <param name="configure">Configure the CSP</param>
+        public static HeaderPolicyCollection AddContentSecurityPolicy(this HeaderPolicyCollection policies, Action<CspBuilder> configure)
+        {
+            return policies.ApplyPolicy(ContentSecurityPolicyHeader.Build(configure));
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeaderExtensions.cs
@@ -18,5 +18,15 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             return policies.ApplyPolicy(ContentSecurityPolicyHeader.Build(configure, asReportOnly));
         }
+
+        /// <summary>
+        /// Add a Content-Security-Header-Report-Only to all requests
+        /// </summary>
+        /// <param name="policies">The collection of policies</param>
+        /// <param name="configure">Configure the CSP</param>
+        public static HeaderPolicyCollection AddContentSecurityPolicyReportOnly(this HeaderPolicyCollection policies, Action<CspBuilder> configure)
+        {
+            return policies.ApplyPolicy(ContentSecurityPolicyHeader.Build(configure, asReportOnly: true));
+        }
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/HtmlOnlyHeaderPolicyBase.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/HtmlOnlyHeaderPolicyBase.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// A base implementation of <see cref="IHeaderPolicy" /> that only adds the header for text/html responses
+    /// </summary>
+    public abstract class HtmlOnlyHeaderPolicyBase : HeaderPolicyBase
+    {
+        ///<inheritdoc />
+        protected HtmlOnlyHeaderPolicyBase(string value) : base(value)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void EvaluateHttpRequest(HttpContext context, CustomHeadersResult result)
+        {
+            if (context.Response.ContentType?.StartsWith("text/html") ?? true)
+            {
+                base.EvaluateHttpRequest(context, result);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void EvaluateHttpsRequest(HttpContext context, CustomHeadersResult result)
+        {
+            if (context.Response.ContentType?.StartsWith("text/html") ?? true)
+            {
+                base.EvaluateHttpsRequest(context, result);
+            }
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/RefererPolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/RefererPolicyHeader.cs
@@ -4,7 +4,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
     /// <summary>
     /// The header value to use for ReferrerPolicy
     /// </summary>
-    public class ReferrerPolicyHeader : HeaderPolicyBase
+    public class ReferrerPolicyHeader : HtmlOnlyHeaderPolicyBase
     {
         /// <inheritdoc />
         public ReferrerPolicyHeader(string value) : base(value)

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XFrameOptionsHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XFrameOptionsHeader.cs
@@ -3,7 +3,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
     /// <summary>
     /// The header value to use for X-Frame-Options
     /// </summary>
-    public class XFrameOptionsHeader : HeaderPolicyBase
+    public class XFrameOptionsHeader : HtmlOnlyHeaderPolicyBase
     {
         /// <inheritdoc />
         public XFrameOptionsHeader(string value) : base(value)

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XFrameOptionsHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XFrameOptionsHeader.cs
@@ -32,5 +32,4 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
             return new XFrameOptionsHeader($"ALLOW-FROM {uri}");
         }
     }
-
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XssProtectionHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XssProtectionHeader.cs
@@ -3,7 +3,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
     /// <summary>
     /// The header value to use for XSS-Protection
     /// </summary>
-    public class XssProtectionHeader : HeaderPolicyBase
+    public class XssProtectionHeader : HtmlOnlyHeaderPolicyBase
     {
         /// <inheritdoc />
         public XssProtectionHeader(string value) : base(value)
@@ -52,5 +52,4 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
             return new XssProtectionHeader($"1; report={reportingUrl}");
         }
     }
-
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/DefaultCustomHeaderPolicyProvider.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/DefaultCustomHeaderPolicyProvider.cs
@@ -8,6 +8,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
     /// <summary>
     /// A type which can provide a <see cref="HeaderPolicyCollection"/> for a particular <see cref="HttpContext"/>.
     /// </summary>
+    [Obsolete("This class is obsolete, and will be removed in a future version of the package")]
     public class DefaultCustomHeaderPolicyProvider : ICustomHeaderPolicyProvider
     {
         private readonly CustomHeaderOptions _options;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/ICustomHeaderPolicyProvider.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/ICustomHeaderPolicyProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
@@ -6,6 +7,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
     /// <summary>
     /// A type which can provide a <see cref="HeaderPolicyCollection"/> for a particular <see cref="HttpContext"/>.
     /// </summary>
+    [Obsolete("This interface is obsolete, and will be removed in a future version of the package")]
     public interface ICustomHeaderPolicyProvider
     {
         /// <summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/NetEscapades.AspNetCore.SecurityHeaders.csproj
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/NetEscapades.AspNetCore.SecurityHeaders.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Security header middleware and for ASP.NET Core to automatically add security headers to requests.</Description>
-    <VersionPrefix>0.4.1</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <Authors>Andrew Lock</Authors>
     <TargetFrameworks>net451;netstandard1.3;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Properties/AssemblyInfo.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Properties/AssemblyInfo.cs
@@ -17,3 +17,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("99ae9045-0537-4724-b49b-3a463e24f743")]
+[assembly: InternalsVisibleTo("NetEscapades.AspNetCore.SecurityHeaders.Test")]

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// An ASP.NET Core middleware for adding security headers.
+    /// </summary>
+    public class SecurityHeadersMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly HeaderPolicyCollection _policy;
+        private readonly ICustomHeaderService _service;
+
+        /// <summary>
+        /// Instantiates a new <see cref="CustomHeadersMiddleware"/>.
+        /// </summary>
+        /// <param name="next">The next middleware in the pipeline.</param>
+        /// <param name="service">An instance of <see cref="ICustomHeaderService"/>.</param>
+        /// <param name="policy">A <see cref="HeaderPolicyCollection"/> containing the policies to be applied.</param>
+        public SecurityHeadersMiddleware(RequestDelegate next, ICustomHeaderService service, HeaderPolicyCollection policy)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+            _policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        }
+
+        /// <summary>
+        /// Invoke the middleware
+        /// </summary>
+        /// <param name="context">The current context</param>
+        /// <returns></returns>
+        public async Task Invoke(HttpContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            context.Response.OnStarting(() =>
+            {
+                var result = _service.EvaluatePolicy(context, _policy);
+                _service.ApplyResult(context.Response, result);
+#if NET451
+                return Task.FromResult(true);
+#else
+                return Task.CompletedTask;
+#endif
+            });
+
+            await _next(context);
+        }
+
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddlewareExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddlewareExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using NetEscapades.AspNetCore.SecurityHeaders;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// The <see cref="IApplicationBuilder"/> extensions for adding Security headers middleware support.
+    /// </summary>
+    public static class SecurityHeadersMiddlewareExtensions
+    {
+        /// <summary>
+        /// Adds middleware to your web application pipeline to automatically add security headers to requests
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
+        /// <param name="policies">A configured policy collection.</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app, HeaderPolicyCollection policies)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (policies == null)
+            {
+                throw new ArgumentNullException(nameof(policies));
+            }
+
+            var service = app.ApplicationServices.GetService(typeof(ICustomHeaderService)) ?? new CustomHeaderService();
+            
+            return app.UseMiddleware<SecurityHeadersMiddleware>(service, policies);
+        }
+
+        /// <summary>
+        /// Adds middleware to your web application pipeline to automatically add security headers to requests
+        /// 
+        /// Adds a policy collection configured using the default security headers, as in <see cref="HeaderPolicyCollectionExtensions.AddDefaultSecurityHeaders"/>
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app)
+        {
+            var policies = new HeaderPolicyCollection()
+                .AddDefaultSecurityHeaders();
+
+            return app.UseSecurityHeaders(policies);
+        }
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+using Xunit;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Test
+{
+    public class CspBuilderTests
+    {
+        [Fact]
+        public void Build_WhenNoValues_ReturnsNull()
+        {
+            var builder = new CspBuilder();
+
+            var result = builder.Build();
+
+            result.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void Build_AddDefaultSrc_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddDefaultSrc()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("default-src 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddConnectSrc_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddConnectSrc()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("connect-src 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddFontSrc_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddFontSrc()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("font-src 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddObjectSrc_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddObjectSrc()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("object-src 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddFormAction_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddFormAction()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("form-action 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddImgSrc_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddImgSrc()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("img-src 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddSrciptSrc_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddScriptSrc()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("script-src 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddStyleSrc_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddStyleSrc()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("style-src 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddMediaSrc_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddMediaSrc()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("media-src 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddFrameAncestors_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddFrameAncestors()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("frame-ancestors 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddFrameSrc_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddFrameSource()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("frame-src 'self' blob: data: http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_AddUpgradeInsecureRequests_AddsValue()
+        {
+            var builder = new CspBuilder()
+                .AddUpgradeInsecureRequests();
+
+            var result = builder.Build();
+
+            result.Should().Be("upgrade-insecure-requests");
+        }
+
+        [Fact]
+        public void Build_AddDefaultSrc_WhenIncludesNone_OnlyWritesNone()
+        {
+            var builder = new CspBuilder();
+            builder.AddDefaultSrc()
+                .Self()
+                .Blob()
+                .Data()
+                .From("http://testUrl.com")
+                .None();
+
+            var result = builder.Build();
+
+            result.Should().Be("default-src 'none'");
+        }
+
+        [Fact]
+        public void Build_ReportUri_AddsValue()
+        {
+            var builder = new CspBuilder()
+                .AddReportUri()
+                    .To("http://testUrl.com");
+
+            var result = builder.Build();
+
+            result.Should().Be("report-uri http://testUrl.com");
+        }
+
+        [Fact]
+        public void Build_CustomDirective_AddsValues()
+        {
+            var builder = new CspBuilder();
+            builder.AddCustomDirective("report-to");
+            builder.AddCustomDirective("plugin-types", "application/x-shockwave-flash");
+
+            var result = builder.Build();
+
+            result.Should().Be("report-to; plugin-types application/x-shockwave-flash");
+        }
+
+        [Fact]
+        public void Build_AddingTheSameDirectiveTwice_OverwritesThePreviousCopy()
+        {
+            var builder = new CspBuilder();
+            builder.AddDefaultSrc().Self();
+            builder.AddDefaultSrc().None();
+
+            var result = builder.Build();
+
+            result.Should().Be("default-src 'none'");
+
+        }
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CustomHeaderMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CustomHeaderMiddlewareTests.cs
@@ -41,13 +41,13 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 // Assert
                 response.EnsureSuccessStatusCode();
 
-                Assert.Equal("Test response", await response.Content.ReadAsStringAsync());
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
                 var header = response.Headers.GetValues("X-Content-Type-Options").FirstOrDefault();
-                Assert.Equal(header, "nosniff");
+                header.Should().Be("nosniff");
                 header = response.Headers.GetValues("X-Frame-Options").FirstOrDefault();
-                Assert.Equal(header, "DENY");
+                header.Should().Be("DENY");
                 header = response.Headers.GetValues("X-XSS-Protection").FirstOrDefault();
-                Assert.Equal(header, "1; mode=block");
+                header.Should().Be("1; mode=block");
 
                 Assert.False(response.Headers.Contains("Server"),
                     "Should not contain server header");
@@ -85,15 +85,15 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 // Assert
                 response.EnsureSuccessStatusCode();
 
-                Assert.Equal("Test response", await response.Content.ReadAsStringAsync());
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
                 var header = response.Headers.GetValues("X-Content-Type-Options").FirstOrDefault();
-                Assert.Equal(header, "nosniff");
+                header.Should().Be("nosniff");
                 header = response.Headers.GetValues("X-Frame-Options").FirstOrDefault();
-                Assert.Equal(header, "DENY");
+                header.Should().Be("DENY");
                 header = response.Headers.GetValues("X-XSS-Protection").FirstOrDefault();
-                Assert.Equal(header, "1; mode=block");
+                header.Should().Be("1; mode=block");
                 header = response.Headers.GetValues("Strict-Transport-Security").FirstOrDefault();
-                Assert.Equal(header, $"max-age={StrictTransportSecurityHeader.OneYearInSeconds}");
+                header.Should().Be($"max-age={StrictTransportSecurityHeader.OneYearInSeconds}");
 
                 Assert.False(response.Headers.Contains("Server"),
                     "Should not contain server header");
@@ -126,9 +126,9 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 // Assert
                 response.EnsureSuccessStatusCode();
 
-                Assert.Equal("Test response", await response.Content.ReadAsStringAsync());
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
                 var header = response.Headers.GetValues("X-My-Test-Header").FirstOrDefault();
-                Assert.Equal(header, "Header value");
+                header.Should().Be("Header value");
             }
         }
 
@@ -159,8 +159,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 // Assert
                 response.EnsureSuccessStatusCode();
 
-                Assert.Equal("Test response", await response.Content.ReadAsStringAsync());
-                Assert.Empty(response.Headers);
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                response.Headers.Should().BeEmpty();
             }
         }
 

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CustomHeaderMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CustomHeaderMiddlewareTests.cs
@@ -19,7 +19,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
+                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                            {
                                app.UseSecurityHeaders(
@@ -63,7 +63,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
             // Arrange
             var hostBuilder = new WebHostBuilder()
                 .UseUrls("https://localhost:5001")
-                .ConfigureServices(services => services.AddCustomHeaders())
+                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                            {
                                app.UseSecurityHeaders(
@@ -107,7 +107,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
+                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                            {
                                app.UseSecurityHeaders(
@@ -140,7 +140,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
+                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                            {
                                app.UseSecurityHeaders(
@@ -173,7 +173,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
+                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                 {
                     app.UseSecurityHeaders(
@@ -212,7 +212,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
+                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                 {
                     app.UseSecurityHeaders(
@@ -252,7 +252,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
+                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                 {
                     app.UseSecurityHeaders(
@@ -289,7 +289,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
+                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                 {
                     app.UseSecurityHeaders(

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CustomHeaderMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CustomHeaderMiddlewareTests.cs
@@ -22,7 +22,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                            {
-                               app.UseCustomHeadersMiddleware(
+                               app.UseSecurityHeaders(
                                    new HeaderPolicyCollection()
                                        .AddDefaultSecurityHeaders());
                                app.Run(async context =>
@@ -66,7 +66,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                            {
-                               app.UseCustomHeadersMiddleware(
+                               app.UseSecurityHeaders(
                                    new HeaderPolicyCollection()
                                        .AddDefaultSecurityHeaders());
                                app.Run(async context =>
@@ -110,7 +110,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                            {
-                               app.UseCustomHeadersMiddleware(
+                               app.UseSecurityHeaders(
                                    new HeaderPolicyCollection()
                                        .AddCustomHeader("X-My-Test-Header", "Header value"));
                                app.Run(async context =>
@@ -143,7 +143,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                            {
-                               app.UseCustomHeadersMiddleware(
+                               app.UseSecurityHeaders(
                                    new HeaderPolicyCollection()
                                        .AddCustomHeader("X-My-Test-Header", "Header value")
                                        .RemoveCustomHeader("X-My-Test-Header"));
@@ -176,7 +176,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                 {
-                    app.UseCustomHeadersMiddleware(
+                    app.UseSecurityHeaders(
                         new HeaderPolicyCollection()
                             .AddContentSecurityPolicy(builder =>
                             {
@@ -215,7 +215,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                 {
-                    app.UseCustomHeadersMiddleware(
+                    app.UseSecurityHeaders(
                         new HeaderPolicyCollection()
                             .AddContentSecurityPolicy(builder =>
                             {
@@ -255,7 +255,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                 {
-                    app.UseCustomHeadersMiddleware(
+                    app.UseSecurityHeaders(
                         new HeaderPolicyCollection()
                             .AddContentSecurityPolicy(builder =>
                             {
@@ -292,7 +292,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                 {
-                    app.UseCustomHeadersMiddleware(
+                    app.UseSecurityHeaders(
                         new HeaderPolicyCollection()
                             .AddContentSecurityPolicy(builder =>
                             {

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CustomHeaderMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CustomHeaderMiddlewareTests.cs
@@ -19,7 +19,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                            {
                                app.UseSecurityHeaders(
@@ -63,7 +62,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
             // Arrange
             var hostBuilder = new WebHostBuilder()
                 .UseUrls("https://localhost:5001")
-                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                            {
                                app.UseSecurityHeaders(
@@ -107,7 +105,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                            {
                                app.UseSecurityHeaders(
@@ -140,7 +137,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                            {
                                app.UseSecurityHeaders(
@@ -173,7 +169,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                 {
                     app.UseSecurityHeaders(
@@ -212,7 +207,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                 {
                     app.UseSecurityHeaders(
@@ -252,7 +246,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                 {
                     app.UseSecurityHeaders(
@@ -292,7 +285,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                 {
                     app.UseSecurityHeaders(
@@ -329,7 +321,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddSecurityHeaders())
                 .Configure(app =>
                 {
                     app.UseSecurityHeaders(

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpSecurityHeadersMiddlewareFunctionalTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpSecurityHeadersMiddlewareFunctionalTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
@@ -30,22 +31,24 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
             var response = await Client.SendAsync(request);
 
             // Assert
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             var content = await response.Content.ReadAsStringAsync();
-            Assert.Equal(path, content);
+            content.Should().Be(path);
             var responseHeaders = response.Headers;
             var header = response.Headers.GetValues("X-Content-Type-Options").FirstOrDefault();
-            Assert.Equal(header, "nosniff");
+            header.Should().Be("nosniff");
             header = response.Headers.GetValues("X-Frame-Options").FirstOrDefault();
-            Assert.Equal(header, "DENY");
+            header.Should().Be("DENY");
             header = response.Headers.GetValues("X-XSS-Protection").FirstOrDefault();
-            Assert.Equal(header, "1; mode=block");
+            header.Should().Be("1; mode=block");
             header = response.Headers.GetValues("Referrer-Policy").FirstOrDefault();
-            Assert.Equal(header, "origin-when-cross-origin");
+            header.Should().Be("origin-when-cross-origin");
+            header = response.Headers.GetValues("Content-Security-Policy").FirstOrDefault();
+            header.Should().Be("object-src 'none'; form-action 'self'; frame-ancestors 'none'");
 
             //http so no Strict transport
-            Assert.DoesNotContain(responseHeaders, x => x.Key == "Strict-Transport-Security");
-            Assert.DoesNotContain(responseHeaders, x => x.Key == "Server");
+            responseHeaders.Should().NotContain(x => x.Key == "Strict-Transport-Security");
+            responseHeaders.Should().NotContain(x => x.Key == "Server");
         }
     }
 }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpsSecurityHeadersMiddlewareFunctionalTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpsSecurityHeadersMiddlewareFunctionalTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 
@@ -37,18 +38,19 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
             var responseHeaders = response.Headers;
 
             var header = response.Headers.GetValues("X-Content-Type-Options").FirstOrDefault();
-            Assert.Equal(header, "nosniff");
+            header.Should().Be("nosniff");
             header = response.Headers.GetValues("X-Frame-Options").FirstOrDefault();
-            Assert.Equal(header, "DENY");
+            header.Should().Be("DENY");
             header = response.Headers.GetValues("X-XSS-Protection").FirstOrDefault();
-            Assert.Equal(header, "1; mode=block");
-            header = response.Headers.GetValues("Strict-Transport-Security").FirstOrDefault();
-            Assert.Equal(header, $"max-age={StrictTransportSecurityHeader.OneYearInSeconds}");
+            header.Should().Be("1; mode=block");
             header = response.Headers.GetValues("Referrer-Policy").FirstOrDefault();
-            Assert.Equal(header, "origin-when-cross-origin");
+            header.Should().Be("origin-when-cross-origin");
+            header = response.Headers.GetValues("Strict-Transport-Security").FirstOrDefault();
+            header.Should().Be($"max-age={StrictTransportSecurityHeader.OneYearInSeconds}");
+            header = response.Headers.GetValues("Content-Security-Policy").FirstOrDefault();
+            header.Should().Be("object-src 'none'; form-action 'self'; frame-ancestors 'none'");
 
-            //http so no Strict transport
-            Assert.DoesNotContain(responseHeaders, x => x.Key == "Server");
+            responseHeaders.Should().NotContain(x => x.Key == "Server");
         }
     }
 }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/NetEscapades.AspNetCore.SecurityHeaders.Test.csproj
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/NetEscapades.AspNetCore.SecurityHeaders.Test.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/NetEscapades.AspNetCore.SecurityHeaders.Test.csproj
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/NetEscapades.AspNetCore.SecurityHeaders.Test.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -12,18 +12,16 @@ using Xunit;
 
 namespace NetEscapades.AspNetCore.SecurityHeaders
 {
-    [Obsolete]
-    public class CustomHeaderMiddlewareTests
+    public class SecurityHeadersMiddlewareTests
     {
         [Fact]
         public async Task HttpRequest_WithDefaultSecurityPolicy_SetsSecurityHeaders()
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                            {
-                               app.UseCustomHeadersMiddleware(
+                               app.UseSecurityHeaders(
                                    new HeaderPolicyCollection()
                                        .AddDefaultSecurityHeaders());
                                app.Run(async context =>
@@ -63,11 +61,10 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
                 .UseUrls("https://localhost:5001")
                 .Configure(app =>
                            {
-                               app.UseCustomHeadersMiddleware(
+                               app.UseSecurityHeaders(
                                    new HeaderPolicyCollection()
                                        .AddDefaultSecurityHeaders());
                                app.Run(async context =>
@@ -108,10 +105,9 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                            {
-                               app.UseCustomHeadersMiddleware(
+                               app.UseSecurityHeaders(
                                    new HeaderPolicyCollection()
                                        .AddCustomHeader("X-My-Test-Header", "Header value"));
                                app.Run(async context =>
@@ -141,10 +137,9 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
-                {
-                               app.UseCustomHeadersMiddleware(
+                           {
+                               app.UseSecurityHeaders(
                                    new HeaderPolicyCollection()
                                        .AddCustomHeader("X-My-Test-Header", "Header value")
                                        .RemoveCustomHeader("X-My-Test-Header"));
@@ -174,10 +169,9 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                 {
-                    app.UseCustomHeadersMiddleware(
+                    app.UseSecurityHeaders(
                         new HeaderPolicyCollection()
                             .AddContentSecurityPolicy(builder =>
                             {
@@ -213,10 +207,9 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                 {
-                    app.UseCustomHeadersMiddleware(
+                    app.UseSecurityHeaders(
                         new HeaderPolicyCollection()
                             .AddContentSecurityPolicy(builder =>
                             {
@@ -253,10 +246,9 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                 {
-                    app.UseCustomHeadersMiddleware(
+                    app.UseSecurityHeaders(
                         new HeaderPolicyCollection()
                             .AddContentSecurityPolicyReportOnly(builder =>
                             {
@@ -288,15 +280,14 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
             }
         }
 
-        // [Fact] Doesn't work with obsolete middleware
+        [Fact]
         public async Task HttpRequest_WithCspHeaderAndNonHtmlContentType_DoesNotSetCspHeader()
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                 {
-                    app.UseCustomHeadersMiddleware(
+                    app.UseSecurityHeaders(
                         new HeaderPolicyCollection()
                             .AddContentSecurityPolicy(builder =>
                             {
@@ -330,10 +321,9 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         {
             // Arrange
             var hostBuilder = new WebHostBuilder()
-                .ConfigureServices(services => services.AddCustomHeaders())
                 .Configure(app =>
                 {
-                    app.UseCustomHeadersMiddleware(
+                    app.UseSecurityHeaders(
                         new HeaderPolicyCollection()
                             .AddContentSecurityPolicy(builder =>
                             {

--- a/test/SecurityHeadersMiddlewareWebSite/EchoMiddleware.cs
+++ b/test/SecurityHeadersMiddlewareWebSite/EchoMiddleware.cs
@@ -27,7 +27,7 @@ namespace SecurityHeadersMiddlewareWebSite
                 throw new ArgumentNullException(nameof(context));
             }
 
-            context.Response.ContentType = "text/plain; charset=utf-8";
+            context.Response.ContentType = "text/html; charset=utf-8";
             var path = context.Request.PathBase + context.Request.Path + context.Request.QueryString;
             return context.Response.WriteAsync(path, Encoding.UTF8);
         }

--- a/test/SecurityHeadersMiddlewareWebSite/Startup.cs
+++ b/test/SecurityHeadersMiddlewareWebSite/Startup.cs
@@ -16,7 +16,7 @@ namespace SecurityHeadersMiddlewareWebSite
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddCustomHeaders();
+            services.AddSecurityHeaders();
         }
 
         public void Configure(IApplicationBuilder app)

--- a/test/SecurityHeadersMiddlewareWebSite/Startup.cs
+++ b/test/SecurityHeadersMiddlewareWebSite/Startup.cs
@@ -21,7 +21,7 @@ namespace SecurityHeadersMiddlewareWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.UseCustomHeadersMiddleware();
+            app.UseSecurityHeaders();
             app.UseMiddleware<EchoMiddleware>();
         }
 

--- a/test/SecurityHeadersMiddlewareWebSite/Startup.cs
+++ b/test/SecurityHeadersMiddlewareWebSite/Startup.cs
@@ -21,9 +21,7 @@ namespace SecurityHeadersMiddlewareWebSite
 
         public void Configure(IApplicationBuilder app)
         {
-            app.UseCustomHeadersMiddleware(
-                new HeaderPolicyCollection()
-                    .AddDefaultSecurityHeaders());
+            app.UseCustomHeadersMiddleware();
             app.UseMiddleware<EchoMiddleware>();
         }
 

--- a/test/SecurityHeadersMiddlewareWebSite/Startup.cs
+++ b/test/SecurityHeadersMiddlewareWebSite/Startup.cs
@@ -16,7 +16,6 @@ namespace SecurityHeadersMiddlewareWebSite
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSecurityHeaders();
         }
 
         public void Configure(IApplicationBuilder app)


### PR DESCRIPTION
Add CSP header implementation
Don't add unnecessary headers to non-html requests
Add an extra overload for `UseCustomHeadersMiddleware()`
