### PR TITLE
Add support for multiple named policies and returning different headers per request

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/DefaultSecurityHeadersPolicyProvider.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/DefaultSecurityHeadersPolicyProvider.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <inheritdoc />
+    public class DefaultSecurityHeadersPolicyProvider : ISecurityHeadersPolicyProvider
+    {
+        private readonly SecurityHeadersOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultSecurityHeadersPolicyProvider"/> class.
+        /// </summary>
+        /// <param name="options">The options configured for the application.</param>
+        public DefaultSecurityHeadersPolicyProvider(IOptions<SecurityHeadersOptions> options)
+        {
+            _options = options.Value;
+        }
+
+        /// <inheritdoc />
+        public Task<HeaderPolicyCollection> GetPolicyAsync(HttpContext context, string policyName)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return Task.FromResult(_options.GetPolicy(policyName ?? _options.DefaultPolicyName));
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/ISecurityHeadersPolicyProvider.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/ISecurityHeadersPolicyProvider.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// A type which can provide a <see cref="HeaderPolicyCollection"/> for a particular <see cref="HttpContext"/>.
+    /// </summary>
+    public interface ISecurityHeadersPolicyProvider
+    {
+        /// <summary>
+        /// Gets a <see cref="HeaderPolicyCollection"/> from the given <paramref name="context"/>
+        /// </summary>
+        /// <param name="context">The <see cref="HttpContext"/> associated with this call.</param>
+        /// <param name="policyName">An optional policy name to look for.</param>
+        /// <returns>A <see cref="HeaderPolicyCollection"/></returns>
+        Task<HeaderPolicyCollection> GetPolicyAsync(HttpContext context, string policyName);
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/SecurityHeadersOptions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/SecurityHeadersOptions.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Builder;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
+{
+    /// <summary>
+    /// Provides programmatic configuration for Security Headers.
+    /// </summary>
+    public class SecurityHeadersOptions
+    {
+        private string _defaultPolicyName = "__DefaultSecurityHeadersPolicy";
+
+        /// <summary>
+        /// The collections of policies to apply
+        /// </summary>
+        /// <returns>The collection of policies, indexed by header name</returns>
+        private IDictionary<string, HeaderPolicyCollection> PolicyMap { get; } = new Dictionary<string, HeaderPolicyCollection>();
+
+        /// <summary>
+        /// Gets or sets the name of the default policy
+        /// </summary>
+        /// <returns>The name of the default policy</returns>
+        public string DefaultPolicyName
+        {
+            get => _defaultPolicyName;
+            set => _defaultPolicyName = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
+        /// Adds a new policy and sets it as the default.
+        /// </summary>
+        /// <param name="policy">The <see cref="HeaderPolicyCollection"/> policy to be added.</param>
+        public void AddDefaultPolicy(HeaderPolicyCollection policy)
+        {
+            if (policy == null)
+            {
+                throw new ArgumentNullException(nameof(policy));
+            }
+
+            AddPolicy(DefaultPolicyName, policy);
+        }
+
+        /// <summary>
+        /// Adds a new policy and sets it as the default.
+        /// </summary>
+        /// <param name="configurePolicy">A delegate which can use a policy builder to build a policy.</param>
+        public void AddDefaultPolicy(Action<HeaderPolicyCollection> configurePolicy)
+        {
+            if (configurePolicy == null)
+            {
+                throw new ArgumentNullException(nameof(configurePolicy));
+            }
+
+            AddPolicy(DefaultPolicyName, configurePolicy);
+        }
+
+        /// <summary>
+        /// Adds a new policy.
+        /// </summary>
+        /// <param name="name">The name of the policy.</param>
+        /// <param name="policy">The <see cref="HeaderPolicyCollection"/> policy to be added.</param>
+        public void AddPolicy(string name, HeaderPolicyCollection policy)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            PolicyMap[name] = policy ?? throw new ArgumentNullException(nameof(policy));
+        }
+
+        /// <summary>
+        /// Adds a new policy.
+        /// </summary>
+        /// <param name="name">The name of the policy.</param>
+        /// <param name="configurePolicy">A delegate which can use a policy builder to build a policy.</param>
+        public void AddPolicy(string name, Action<HeaderPolicyCollection> configurePolicy)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (configurePolicy == null)
+            {
+                throw new ArgumentNullException(nameof(configurePolicy));
+            }
+
+            var policyBuilder = new HeaderPolicyCollection();
+            configurePolicy(policyBuilder);
+            PolicyMap[name] = policyBuilder;
+        }
+
+        /// <summary>
+        /// Gets the policy based on the <paramref name="name"/>
+        /// </summary>
+        /// <param name="name">The name of the policy to lookup.</param>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> if the policy was added.<c>null</c> otherwise.</returns>
+        public HeaderPolicyCollection GetPolicy(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            return PolicyMap.TryGetValue(name, out var policies) ? policies : null;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddlewareExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddlewareExtensions.cs
@@ -11,6 +11,28 @@ namespace Microsoft.AspNetCore.Builder
     public static class SecurityHeadersMiddlewareExtensions
     {
         /// <summary>
+        /// Adds middleware to your web application pipeline to automatically add security headers to requests.
+        /// It is required to call <see cref="SecurityHeadersServiceCollectionExtensions.AddSecurityHeaders(Microsoft.Extensions.DependencyInjection.IServiceCollection)"/> in ConfigureServices.
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your Configure method</param>
+        /// <param name="policyName">The policy name of a configured policy.</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app, string policyName)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (policyName == null)
+            {
+                return app.UseMiddleware<SecurityHeadersMiddleware>();
+            }
+
+            return app.UseMiddleware<SecurityHeadersMiddleware>(policyName);
+        }
+
+        /// <summary>
         /// Adds middleware to your web application pipeline to automatically add security headers to requests
         /// </summary>
         /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
@@ -55,7 +77,9 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Adds middleware to your web application pipeline to automatically add security headers to requests
         ///
-        /// Adds a policy collection configured using the default security headers, as in <see cref="HeaderPolicyCollectionExtensions.AddDefaultSecurityHeaders"/>
+        /// Adds a policy collection configured using the default security headers, as in <see cref="HeaderPolicyCollectionExtensions.AddDefaultSecurityHeaders"/>.
+        /// If the default security headers are not desired, use the <see cref="UseSecurityHeaders(IApplicationBuilder, string)"/> overload and
+        /// pass <c>null</c> as the policy name.
         /// </summary>
         /// <param name="app">The IApplicationBuilder passed to your Configure method.</param>
         /// <returns>The original app parameter</returns>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersServiceCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersServiceCollectionExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders
+{
+    /// <summary>
+    /// Extension methods for setting up security headers services in an <see cref="IServiceCollection"/>.
+    /// </summary>
+    public static class SecurityHeadersServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds security headers services to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddSecurityHeaders(this IServiceCollection services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.AddOptions();
+
+            services.TryAdd(ServiceDescriptor.Transient<ICustomHeaderService, CustomHeaderService>());
+            services.TryAdd(ServiceDescriptor.Transient<ISecurityHeadersPolicyProvider, DefaultSecurityHeadersPolicyProvider>());
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds security headers services to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+        /// <param name="setupAction">An <see cref="Action{T}"/> to configure the provided <see cref="SecurityHeadersOptions"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddSecurityHeaders(this IServiceCollection services, Action<SecurityHeadersOptions> setupAction)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (setupAction == null)
+            {
+                throw new ArgumentNullException(nameof(setupAction));
+            }
+
+            services.AddSecurityHeaders();
+            services.Configure(setupAction);
+
+            return services;
+        }
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/Mocks/CustomSecurityHeadersPolicyProvider.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/Mocks/CustomSecurityHeadersPolicyProvider.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Test.Mocks
+{
+    /// <summary>
+    /// If policy name is null, automatically select policy depending on request path.
+    /// </summary>
+    public class CustomSecurityHeadersPolicyProvider : ISecurityHeadersPolicyProvider
+    {
+        private readonly SecurityHeadersOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomSecurityHeadersPolicyProvider"/> class.
+        /// </summary>
+        /// <param name="options">The options configured for the application.</param>
+        public CustomSecurityHeadersPolicyProvider(IOptions<SecurityHeadersOptions> options)
+        {
+            _options = options.Value;
+        }
+
+        /// <inheritdoc />
+        public Task<HeaderPolicyCollection> GetPolicyAsync(HttpContext context, string policyName)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (policyName == null && context.Request.Path == "/signout-oidc")
+            {
+                policyName = "AllowFrame";
+            }
+
+            return Task.FromResult(_options.GetPolicy(policyName ?? _options.DefaultPolicyName));
+        }
+    }
+}


### PR DESCRIPTION
Modelled after CorsMiddleware. Attribute to choose policy name per endpoint is not done yet.