### PR TITLE
Mark CustomHeaderOptions as obsolete.

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderOptions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderOptions.cs
@@ -7,6 +7,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
     /// <summary>
     /// Provides programmatic configuration for Security Headers.
     /// </summary>
+    [Obsolete("This class is unused since v0.5.0, and will be removed in a future version of the package")]
     public class CustomHeaderOptions
     {
         private string _defaultPolicyName = "__DefaultSecurityHeadersPolicy";


### PR DESCRIPTION
It was used by the old DefaultCustomHeaderPolicyProvider.