### PR TITLE
Added SPDX license identifiers

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.csproj
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.csproj
@@ -10,6 +10,7 @@
         <AssemblyName>NetEscapades.AspNetCore.SecurityHeaders.TagHelpers</AssemblyName>
         <PackageId>NetEscapades.AspNetCore.SecurityHeaders.TagHelpers</PackageId>
         <PackageTags>aspnetcore;headers;ASP.NET MVC;ASP.NET Core;Tag Helpers;TagHelpers;Razor</PackageTags>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/NetEscapades.AspNetCore.SecurityHeaders.csproj
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/NetEscapades.AspNetCore.SecurityHeaders.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>NetEscapades.AspNetCore.SecurityHeaders</AssemblyName>
     <PackageId>NetEscapades.AspNetCore.SecurityHeaders</PackageId>
     <PackageTags>aspnetcore;headers;ASP.NET MVC;ASP.NET Core;middleware</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>


### PR DESCRIPTION
This change adds the SPDX license identifier to the generated NuGet packages by adding the appropriate [PackageLicenseExpression](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget) tag.

**Why?** Companies use the license information provided by package managers to ensure compliance across large projects. Providing an SPDX license identifier makes it simpler for people to work with automated tools like [LicenseFinder](https://github.com/pivotal/LicenseFinder) or GitLab's license scanning feature.