### PR TITLE
Add support for Permissions-Policy

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/AccelerometerPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/AccelerometerPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,19 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use the accelerometer sensor.
+    /// If disabled then constructing of a Sensor-based interface object will throw a
+    /// <code>SecurityError</code>. The events are not fired. If an interface (or an
+    /// event) requires access to multiple sensors of different types than each of the
+    /// corresponding sensor features must be allowed in order to use the interface.
+    /// </summary>
+    public class AccelerometerPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AccelerometerPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public AccelerometerPermissionsPolicyDirectiveBuilder() : base("accelerometer")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/AmbientLightSensorPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/AmbientLightSensorPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,19 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use the ambient light sensor sensor.
+    /// If disabled then constructing of a Sensor-based interface object will throw a
+    /// <code>SecurityError</code>. The events are not fired. If an interface (or an
+    /// event) requires access to multiple sensors of different types than each of the
+    /// corresponding sensor features must be allowed in order to use the interface.
+    /// </summary>
+    public class AmbientLightSensorPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AmbientLightSensorPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public AmbientLightSensorPermissionsPolicyDirectiveBuilder() : base("ambient-light-sensor")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/AutoplayPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/AutoplayPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,19 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls access to autoplay of media requested through the
+    /// <code>HTMLMediaElement</code> interface. If disabled in a document,
+    /// then calls to <code>play()</code> without a user gesture will
+    /// reject the promise with a <code>NotAllowedError</code> DOMException
+    /// object as its parameter. The autoplay attribute will be ignored.
+    /// </summary>
+    public class AutoplayPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoplayPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public AutoplayPermissionsPolicyDirectiveBuilder() : base("autoplay")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/CameraPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/CameraPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,18 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls access to video input devices requested through the
+    /// NavigatorUserMedia interface. If disabled in a document, then calls
+    /// to <code>getUserMedia()</code> will not grant access to video input
+    /// devices in that document.
+    /// </summary>
+    public class CameraPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CameraPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public CameraPermissionsPolicyDirectiveBuilder() : base("camera")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/CustomPermissionsPolicyDirective.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/CustomPermissionsPolicyDirective.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Create a custom Permission Policy directive for an un-implemented directive.
+    /// </summary>
+    public class CustomPermissionsPolicyDirective : PermissionsPolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomPermissionsPolicyDirective"/> class.
+        /// Create a custom Permission Policy directive for an un-implemented directive.
+        /// </summary>
+        /// <param name="directive">The feature policy name, e.g. push, or vibrate</param>
+        /// <param name="value">The feature value, e.g. 'self', *, 'none'</param>
+        public CustomPermissionsPolicyDirective(string directive, string value) : base(directive)
+        {
+            if (string.IsNullOrEmpty(directive))
+            {
+                throw new ArgumentException($"{nameof(directive)} must not be null or empty", nameof(directive));
+            }
+
+            Value = value;
+        }
+
+        /// <summary>
+        /// The directive value
+        /// </summary>
+        public string Value { get; }
+
+        /// <inheritdoc />
+        internal override string Build()
+        {
+            if (Value == "*")
+            {
+                return $"{Directive}={Value}";
+            }
+
+            if (string.IsNullOrEmpty(Value))
+            {
+                return $"{Directive}=()";
+            }
+
+            return $"{Directive}=({Value})";
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/CustomPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/CustomPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Create a custom Permission Policy directive for an un-implemented directive.
+    /// </summary>
+    public class CustomPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomPermissionsPolicyDirectiveBuilder"/> class.
+        /// Create a custom Permission Policy directive for an un-implemented directive.
+        /// </summary>
+        /// <param name="directive">The feature policy name, e.g. push, or vibrate</param>
+        public CustomPermissionsPolicyDirectiveBuilder(string directive) : base(directive)
+        {
+            if (string.IsNullOrEmpty(directive))
+            {
+                throw new ArgumentException($"{nameof(directive)} must not be null or empty", nameof(directive));
+            }
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/EncryptedMediaPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/EncryptedMediaPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,18 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether encrypted media extensions are available. If disabled
+    /// The promise returned by <code>requestMediaKeySystemAccess()</code> must
+    /// return a promise which rejects with a <code>SecurityError</code> DOMException
+    /// object as its parameter.
+    /// </summary>
+    public class EncryptedMediaPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EncryptedMediaPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public EncryptedMediaPermissionsPolicyDirectiveBuilder() : base("encrypted-media")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/FullscreenPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/FullscreenPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use
+    /// <code>Element.requestFullScreen()</code>. When this policy is enabled,
+    /// the returned <code>Promise</code> rejects with a <code>TypeError</code>.
+    /// </summary>
+    public class FullscreenPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FullscreenPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public FullscreenPermissionsPolicyDirectiveBuilder() : base("fullscreen")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/GeolocationPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/GeolocationPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,19 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use the
+    /// <code>Geolocation</code> Interface. When this policy is enabled,
+    /// calls to <code>getCurrentPosition()</code> and <code>watchPosition()</code>
+    /// will cause those functions' callbacks to be invoked with a
+    /// <code>PositionError</code> code of <code>PERMISSION_DENIED</code>.
+    /// </summary>
+    public class GeolocationPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GeolocationPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public GeolocationPermissionsPolicyDirectiveBuilder() : base("geolocation")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/GyroscopePermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/GyroscopePermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,19 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use the gyroscope sensor.
+    /// If disabled then constructing of a Sensor-based interface object will throw a
+    /// <code>SecurityError</code>. The events are not fired. If an interface (or an
+    /// event) requires access to multiple sensors of different types than each of the
+    /// corresponding sensor features must be allowed in order to use the interface.
+    /// </summary>
+    public class GyroscopePermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GyroscopePermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public GyroscopePermissionsPolicyDirectiveBuilder() : base("gyroscope")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/MagnetometerPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/MagnetometerPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,19 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use the magnetometer sensor.
+    /// If disabled then constructing of a Sensor-based interface object will throw a
+    /// <code>SecurityError</code>. The events are not fired. If an interface (or an
+    /// event) requires access to multiple sensors of different types than each of the
+    /// corresponding sensor features must be allowed in order to use the interface.
+    /// </summary>
+    public class MagnetometerPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MagnetometerPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public MagnetometerPermissionsPolicyDirectiveBuilder() : base("magnetometer")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/MicrophonePermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/MicrophonePermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,18 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use audio
+    /// input devices. When this policy is enabled, the <code>Promise</code>
+    /// returned by <code>MediaDevices.getUserMedia()</code> will
+    /// reject with a <code>NotAllowedError</code>.
+    /// </summary>
+    public class MicrophonePermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MicrophonePermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public MicrophonePermissionsPolicyDirectiveBuilder() : base("microphone")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/MidiPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/MidiPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,17 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use the Web MIDI API.
+    /// If disabled in a document, the promise returned by <code>requestMIDIAccess()</code>
+    /// must reject with a DOMException parameter.
+    /// </summary>
+    public class MidiPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MidiPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public MidiPermissionsPolicyDirectiveBuilder() : base("midi")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PaymentPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PaymentPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,17 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls  whether the current document is allowed to use the
+    /// PaymentRequest interface. If disabled then calls to the
+    /// <code>PaymentRequest</code> constuctor will throw a <code>SecurityError</code>.
+    /// </summary>
+    public class PaymentPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PaymentPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public PaymentPermissionsPolicyDirectiveBuilder() : base("payment")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyBuilder.cs
@@ -1,0 +1,203 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Used for building a Permissions-Policy header
+    /// </summary>
+    public class PermissionsPolicyBuilder
+    {
+        private readonly Dictionary<string, PermissionsPolicyDirectiveBuilderBase> _directives = new Dictionary<string, PermissionsPolicyDirectiveBuilderBase>();
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use the accelerometer sensor.
+        /// If disabled then constructing of a Sensor-based interface object will throw a
+        /// <code>SecurityError</code>. The events are not fired. If an interface (or an
+        /// event) requires access to multiple sensors of different types than each of the
+        /// corresponding sensor features must be allowed in order to use the interface.
+        /// </summary>
+        /// <returns>A configured <see cref="AccelerometerPermissionsPolicyDirectiveBuilder"/></returns>
+        public AccelerometerPermissionsPolicyDirectiveBuilder AddAccelerometer() => AddDirective(new AccelerometerPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use the ambient light sensor sensor.
+        /// If disabled then constructing of a Sensor-based interface object will throw a
+        /// <code>SecurityError</code>. The events are not fired. If an interface (or an
+        /// event) requires access to multiple sensors of different types than each of the
+        /// corresponding sensor features must be allowed in order to use the interface.
+        /// </summary>
+        /// <returns>A configured <see cref="AmbientLightSensorPermissionsPolicyDirectiveBuilder"/></returns>
+        public AmbientLightSensorPermissionsPolicyDirectiveBuilder AddAmbientLightSensor() => AddDirective(new AmbientLightSensorPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls access to autoplay of media requested through the
+        /// <code>HTMLMediaElement</code> interface. If disabled in a document,
+        /// then calls to <code>play()</code> without a user gesture will
+        /// reject the promise with a <code>NotAllowedError</code> DOMException
+        /// object as its parameter. The autoplay attribute will be ignored.
+        /// </summary>
+        /// <returns>A configured <see cref="AutoplayPermissionsPolicyDirectiveBuilder"/></returns>
+        public AutoplayPermissionsPolicyDirectiveBuilder AddAutoplay() => AddDirective(new AutoplayPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls access to video input devices requested through the
+        /// NavigatorUserMedia interface. If disabled in a document, then calls
+        /// to <code>getUserMedia()</code> will not grant access to video input
+        /// devices in that document.
+        /// </summary>
+        /// <returns>A configured <see cref="CameraPermissionsPolicyDirectiveBuilder"/></returns>
+        public CameraPermissionsPolicyDirectiveBuilder AddCamera() => AddDirective(new CameraPermissionsPolicyDirectiveBuilder());
+
+        ///// <summary>
+        ///// Controls whether encrypted media extensions are available. If disabled
+        ///// The promise returned by <code>requestMediaKeySystemAccess()</code> must
+        ///// return a promise which rejects with a <code>SecurityError</code> DOMException
+        ///// object as its parameter.
+        ///// </summary>
+        ///// <returns>A configured <see cref="EncryptedMediaFeaturePolicyDirectiveBuilder"/></returns>
+        // public EncryptedMediaFeaturePolicyDirectiveBuilder AddEncryptedMedia() => AddDirective(new EncryptedMediaFeaturePolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use
+        /// <code>Element.requestFullScreen()</code>. When this policy is enabled,
+        /// the returned <code>Promise</code> rejects with a <code>TypeError</code>.
+        /// </summary>
+        /// <returns>A configured <see cref="FullscreenPermissionsPolicyDirectiveBuilder"/></returns>
+        public FullscreenPermissionsPolicyDirectiveBuilder AddFullscreen() => AddDirective(new FullscreenPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use the
+        /// <code>Geolocation</code> Interface. When this policy is enabled,
+        /// calls to <code>getCurrentPosition()</code> and <code>watchPosition()</code>
+        /// will cause those functions' callbacks to be invoked with a
+        /// <code>PositionError</code> code of <code>PERMISSION_DENIED</code>.
+        /// </summary>
+        /// <returns>A configured <see cref="GeolocationPermissionsPolicyDirectiveBuilder"/></returns>
+        public GeolocationPermissionsPolicyDirectiveBuilder AddGeolocation() => AddDirective(new GeolocationPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use the gyroscope sensor.
+        /// If disabled then constructing of a Sensor-based interface object will throw a
+        /// <code>SecurityError</code>. The events are not fired. If an interface (or an
+        /// event) requires access to multiple sensors of different types than each of the
+        /// corresponding sensor features must be allowed in order to use the interface.
+        /// </summary>
+        /// <returns>A configured <see cref="GyroscopePermissionsPolicyDirectiveBuilder"/></returns>
+        public GyroscopePermissionsPolicyDirectiveBuilder AddGyroscope() => AddDirective(new GyroscopePermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use the magnetometer sensor.
+        /// If disabled then constructing of a Sensor-based interface object will throw a
+        /// <code>SecurityError</code>. The events are not fired. If an interface (or an
+        /// event) requires access to multiple sensors of different types than each of the
+        /// corresponding sensor features must be allowed in order to use the interface.
+        /// </summary>
+        /// <returns>A configured <see cref="MagnetometerPermissionsPolicyDirectiveBuilder"/></returns>
+        public MagnetometerPermissionsPolicyDirectiveBuilder AddMagnetometer() => AddDirective(new MagnetometerPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use audio
+        /// input devices. When this policy is enabled, the <code>Promise</code>
+        /// returned by <code>MediaDevices.getUserMedia()</code> will
+        /// reject with a <code>NotAllowedError</code>.
+        /// </summary>
+        /// <returns>A configured <see cref="MicrophonePermissionsPolicyDirectiveBuilder"/></returns>
+        public MicrophonePermissionsPolicyDirectiveBuilder AddMicrophone() => AddDirective(new MicrophonePermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use the Web MIDI API.
+        /// If disabled in a document, the promise returned by <code>requestMIDIAccess()</code>
+        /// must reject with a DOMException parameter.
+        /// </summary>
+        /// <returns>A configured <see cref="MidiPermissionsPolicyDirectiveBuilder"/></returns>
+        public MidiPermissionsPolicyDirectiveBuilder AddMidi() => AddDirective(new MidiPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls  whether the current document is allowed to use the
+        /// PaymentRequest interface. If disabled then calls to the
+        /// <code>PaymentRequest</code> constuctor will throw a <code>SecurityError</code>.
+        /// </summary>
+        /// <returns>A configured <see cref="PaymentPermissionsPolicyDirectiveBuilder"/></returns>
+        public PaymentPermissionsPolicyDirectiveBuilder AddPayment() => AddDirective(new PaymentPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use Picture In Picture.
+        /// If disabled in a document, then calls to <code>requestPictureInPicture()</code>
+        /// will throw a <code>SecurityError</code> and <code>pictureInPictureEnabled</code>
+        /// will return <code>false</code>.
+        /// </summary>
+        /// <returns>A configured <see cref="PictureInPicturePermissionsPolicyDirectiveBuilder"/></returns>
+        public PictureInPicturePermissionsPolicyDirectiveBuilder AddPictureInPicture() => AddDirective(new PictureInPicturePermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls access to audio output devices requested through
+        /// the NavigatorUserMedia interface. If disabled then calls to
+        /// <code>getUserMedia()</code> will not grant access to audio
+        /// output devices in that document.
+        /// </summary>
+        /// <returns>A configured <see cref="SpeakerPermissionsPolicyDirectiveBuilder"/></returns>
+        public SpeakerPermissionsPolicyDirectiveBuilder AddSpeaker() => AddDirective(new SpeakerPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use synchronous XMLHttpRequest transfers.
+        /// If disabled in a document, then calls to <code>send()</code> on XMLHttpRequest objects
+        /// will throw a <code>NetworkError</code>.
+        /// </summary>
+        /// <returns>A configured <see cref="SynchronousXhrPermissionsPolicyDirectiveBuilder"/></returns>
+        public SynchronousXhrPermissionsPolicyDirectiveBuilder AddSyncXHR() => AddDirective(new SynchronousXhrPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use the WebUSB API.
+        /// If disabled then calls to <code>getDevices()</code> should return a
+        /// <code>promise</code> which rejects with a <code>SecurityError</code> DOMException.
+        /// </summary>
+        /// <returns>A configured <see cref="UsbPermissionsPolicyDirectiveBuilder"/></returns>
+        public UsbPermissionsPolicyDirectiveBuilder AddUsb() => AddDirective(new UsbPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Controls whether the current document is allowed to use the WebVR API.
+        /// If disabled then calls to <code>getVRDisplays()</code> should return a
+        /// <code>promise</code> which rejects with a <code>SecurityError</code> DOMException.
+        /// </summary>
+        /// <returns>A configured <see cref="VRPermissionsPolicyDirectiveBuilder"/></returns>
+        public VRPermissionsPolicyDirectiveBuilder AddVR() => AddDirective(new VRPermissionsPolicyDirectiveBuilder());
+
+        /// <summary>
+        /// Create a custom Feature-Policy directive for an un-implemented directive.
+        ///
+        /// The directive can be built using standard methods such as <see cref="PermissionsPolicyDirectiveBuilder.Self"/>
+        /// and <see cref="PermissionsPolicyDirectiveBuilder.None"/>
+        /// </summary>
+        /// <param name="directive">The feature policy name, e.g. push, or vibrate</param>
+        /// <returns>A configured <see cref="CustomPermissionsPolicyDirectiveBuilder"/></returns>
+        public CustomPermissionsPolicyDirectiveBuilder AddCustomFeature(string directive) => AddDirective(new CustomPermissionsPolicyDirectiveBuilder(directive));
+
+        /// <summary>
+        /// Create a custom Feature-Policy directive for an un-implemented directive.
+        ///
+        /// The directive can be built using standard methods such as <see cref="PermissionsPolicyDirectiveBuilder.Self"/>
+        /// and <see cref="PermissionsPolicyDirectiveBuilder.None"/>
+        /// </summary>
+        /// <param name="directive">The feature policy name, e.g. push, or vibrate</param>
+        /// <param name="value">The value to use for the directive, e.g. * or 'none'</param>
+        /// <returns>A configured <see cref="CustomPermissionsPolicyDirectiveBuilder"/></returns>
+        public CustomPermissionsPolicyDirective AddCustomFeature(string directive, string value) => AddDirective(new CustomPermissionsPolicyDirective(directive, value));
+
+        private T AddDirective<T>(T directive) where T : PermissionsPolicyDirectiveBuilderBase
+        {
+            _directives[directive.Directive] = directive;
+            return directive;
+        }
+
+        /// <summary>
+        /// Builds the Feature-Policy value.
+        /// </summary>
+        /// <returns>The string representing the complete Feature-Policy value.</returns>
+        internal string Build()
+        {
+            return string.Join(", ", _directives.Values.Select(x => x.Build()).Where(x => !string.IsNullOrEmpty(x)));
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Used to build a Permissions-Policy directive that uses a standard set of sources.
+    /// </summary>
+    public abstract class PermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        /// <param name="directive">The name of the directive.</param>
+        public PermissionsPolicyDirectiveBuilder(string directive) : base(directive)
+        {
+        }
+
+        /// <summary>
+        /// The sources from which the directive is allowed.
+        /// </summary>
+        public List<string> Sources { get; } = new List<string>();
+
+        /// <summary>
+        /// If true, no sources are allowed.
+        /// </summary>
+        internal bool BlockResources { get; set; } = false;
+
+        /// <summary>
+        /// If true, all sources are allowed.
+        /// </summary>
+        internal bool AllowAllResources { get; set; } = false;
+
+        /// <inheritdoc />
+        internal override string Build()
+        {
+            if (BlockResources && AllowAllResources)
+            {
+                throw new InvalidOperationException(
+                    $"Invalid directive values for Permissions-Policy '{Directive}' directive: you cannot both block all resources and allow all values");
+            }
+
+            if (BlockResources)
+            {
+                return $"{Directive}=()";
+            }
+
+            if (AllowAllResources)
+            {
+                return $"{Directive}=*";
+            }
+
+            if (Sources.Count == 1)
+            {
+                return $"{Directive}={Sources.FirstOrDefault()}";
+            }
+
+            return $"{Directive}=({string.Join(" ", Sources)})";
+        }
+
+        /// <summary>
+        /// Enable the feature in top-level browsing contexts and all nested browsing contexts (iframes).
+        /// </summary>
+        /// <returns>The Permissions-Policy builder for method chaining</returns>
+        public PermissionsPolicyDirectiveBuilder All()
+        {
+            AllowAllResources = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable the feature in top-level browsing contexts and all nested browsing contexts (iframes) in the same origin. ]
+        /// The feature is not allowed in cross-origin documents in nested browsing contexts.
+        /// </summary>
+        /// <returns>The Permissions-Policy builder for method chaining</returns>
+        public PermissionsPolicyDirectiveBuilder Self()
+        {
+            Sources.Add("self");
+            return this;
+        }
+
+        /// <summary>
+        /// The feature is disabled in top-level and nested browsing contexts.
+        /// </summary>
+        /// <returns>The Permissions-Policy builder for method chaining</returns>
+        public PermissionsPolicyDirectiveBuilder None()
+        {
+            BlockResources = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable the feature for the specific origin specified in <paramref name="uri"/>. May be any non-empty value
+        /// </summary>
+        /// <param name="uri">The URI to allow.</param>
+        /// <returns>The Permissions-Policy builder for method chaining</returns>
+        public PermissionsPolicyDirectiveBuilder For(string uri)
+        {
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                throw new ArgumentException("Uri may not be null or empty", nameof(uri));
+            }
+
+            Sources.Add($"\"{uri}\"");
+            return this;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyDirectiveBuilderBase.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyDirectiveBuilderBase.cs
@@ -1,0 +1,28 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Base class for building Permissions-Policy directives.
+    /// </summary>
+    public abstract class PermissionsPolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PermissionsPolicyDirectiveBuilderBase"/> class.
+        /// </summary>
+        /// <param name="directive">The name of the directive.</param>
+        public PermissionsPolicyDirectiveBuilderBase(string directive)
+        {
+            Directive = directive;
+        }
+
+        /// <summary>
+        /// The name of the directive.
+        /// </summary>
+        internal string Directive { get; }
+
+        /// <summary>
+        /// Builds the complete directive policy string.
+        /// </summary>
+        /// <returns>The complete directive string.</returns>
+        internal abstract string Build();
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PictureInPicturePermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PictureInPicturePermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,18 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use Picture In Picture.
+    /// If disabled in a document, then calls to <code>requestPictureInPicture()</code>
+    /// will throw a <code>SecurityError</code> and <code>pictureInPictureEnabled</code>
+    /// will return <code>false</code>.
+    /// </summary>
+    public class PictureInPicturePermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PictureInPicturePermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public PictureInPicturePermissionsPolicyDirectiveBuilder() : base("picture-in-picture")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/SpeakerPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/SpeakerPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,18 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls access to audio output devices requested through
+    /// the NavigatorUserMedia interface. If disabled then calls to
+    /// <code>getUserMedia()</code> will not grant access to audio
+    /// output devices in that document.
+    /// </summary>
+    public class SpeakerPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpeakerPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public SpeakerPermissionsPolicyDirectiveBuilder() : base("speaker")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/SynchronousXhrPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/SynchronousXhrPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,17 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use synchronous XMLHttpRequest transfers.
+    /// If disabled in a document, then calls to <code>send()</code> on XMLHttpRequest objects
+    /// will throw a <code>NetworkError</code>.
+    /// </summary>
+    public class SynchronousXhrPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SynchronousXhrPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public SynchronousXhrPermissionsPolicyDirectiveBuilder() : base("sync-xhr")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/UsbPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/UsbPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,17 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use the WebUSB API.
+    /// If disabled then calls to <code>getDevices()</code> should return a
+    /// <code>promise</code> which rejects with a <code>SecurityError</code> DOMException.
+    /// </summary>
+    public class UsbPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsbPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public UsbPermissionsPolicyDirectiveBuilder() : base("usb")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/VRPermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/VRPermissionsPolicyDirectiveBuilder.cs
@@ -1,0 +1,17 @@
+﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
+{
+    /// <summary>
+    /// Controls whether the current document is allowed to use the WebVR API.
+    /// If disabled then calls to <code>getVRDisplays()</code> should return a
+    /// <code>promise</code> which rejects with a <code>SecurityError</code> DOMException.
+    /// </summary>
+    public class VRPermissionsPolicyDirectiveBuilder : PermissionsPolicyDirectiveBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VRPermissionsPolicyDirectiveBuilder"/> class.
+        /// </summary>
+        public VRPermissionsPolicyDirectiveBuilder() : base("vr")
+        {
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeader.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
+{
+    /// <summary>
+    /// The header value to use for Permissions-Policy.
+    /// </summary>
+    public class PermissionsPolicyHeader : HtmlOnlyHeaderPolicyBase
+    {
+        private readonly string _value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PermissionsPolicyHeader"/> class.
+        /// </summary>
+        /// <param name="value">The value to apply for the header</param>
+        public PermissionsPolicyHeader(string value)
+        {
+            _value = value;
+        }
+
+        /// <inheritdoc />
+        public override string Header => "Permissions-Policy";
+
+        /// <inheritdoc />
+        protected override string GetValue(HttpContext context) => _value;
+
+        /// <summary>
+        /// Configure a permission policy.
+        /// </summary>
+        /// <param name="configure">Configure the Permissions-Policy header</param>
+        /// <returns>The complete Permissions-Policy header</returns>
+        public static PermissionsPolicyHeader Build(Action<PermissionsPolicyBuilder> configure)
+        {
+            var builder = new PermissionsPolicyBuilder();
+
+            configure(builder);
+
+            return new PermissionsPolicyHeader(builder.Build());
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeaderExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using NetEscapades.AspNetCore.SecurityHeaders.Headers;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
+{
+    /// <summary>
+    /// Extension methods for adding a <see cref="PermissionsPolicyHeader" /> to a <see cref="HeaderPolicyCollection" />
+    /// </summary>
+    public static class PermissionsPolicyHeaderExtensions
+    {
+        /// <summary>
+        /// Add a Permissions-Policy header to all requests
+        /// </summary>
+        /// <param name="policies">The collection of policies</param>
+        /// <param name="configure">Configure the Permissions-Policy</param>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
+        public static HeaderPolicyCollection AddPermissionsPolicy(this HeaderPolicyCollection policies, Action<PermissionsPolicyBuilder> configure)
+        {
+            return policies.ApplyPolicy(PermissionsPolicyHeader.Build(configure));
+        }
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PermissionsPolicyBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PermissionsPolicyBuilderTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Xunit;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Test
+{
+    public class PermissionsPolicyBuilderTests
+    {
+        [Fact]
+        public void PermissionsPolicy_Build_WhenNoValues_Returns()
+        {
+            var builder = new PermissionsPolicyBuilder();
+
+            var result = builder.Build();
+
+            result.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void PermissionsPolicy_Build_AddSelfOnly_ReturnsOnlySelf()
+        {
+            var builder = new PermissionsPolicyBuilder();
+
+            builder.AddAccelerometer()
+              .Self();
+
+            var result = builder.Build();
+
+            result.Should().Be("accelerometer=self");
+        }
+
+        [Fact]
+        public void PermissionsPolicy_Build_AddAccelerometer_WhenAddsMultipleValue_ReturnsAllValues()
+        {
+            var builder = new PermissionsPolicyBuilder();
+
+            builder.AddAccelerometer()
+              .Self()
+              .For("http://testUrl.com").For("https://testUrl2.se");
+
+            var result = builder.Build();
+
+            result.Should().Be("accelerometer=(self \"http://testUrl.com\" \"https://testUrl2.se\")");
+        }
+
+        [Fact]
+        public void PermissionsPolicy_Build_AddAccelerometer_WhenIncludesNone_OnlyWritesNone()
+        {
+            var builder = new PermissionsPolicyBuilder();
+            builder.AddAccelerometer()
+                .Self()
+                .For("http://testUrl.com")
+                .None();
+
+            var result = builder.Build();
+
+            result.Should().Be("accelerometer=()");
+        }
+
+        [Fact]
+        public void PermissionsBuild_AddAccelerometer_WhenIncludesAll_OnlyWritesAll()
+        {
+            var builder = new PermissionsPolicyBuilder();
+            builder.AddAccelerometer()
+                .Self()
+                .For("http://testUrl.com")
+                .All();
+
+            var result = builder.Build();
+
+            result.Should().Be("accelerometer=*");
+        }
+
+        [Fact]
+        public void PermissionsPolicy_Build_AddAccelerometer_WhenIncludesAllAndNone_ThrowsInvalidOperationException()
+        {
+            var builder = new PermissionsPolicyBuilder();
+            builder.AddAccelerometer()
+                .None()
+                .All();
+
+            Assert.Throws<InvalidOperationException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void PermissionsPolicy_Build_CustomPermissionsPolicyDirective_AddsValues()
+        {
+            var builder = new PermissionsPolicyBuilder();
+            builder.AddCustomFeature("push", string.Empty);
+            builder.AddCustomFeature("vibrate", "*");
+            builder.AddCustomFeature("something-else", string.Empty);
+
+            var result = builder.Build();
+
+            result.Should().Be("push=(), vibrate=*, something-else=()");
+        }
+
+        [Fact]
+        public void PermissionsPolicy_Build_CustomPermissionsPolicyBuilder_AddsValues()
+        {
+            var builder = new PermissionsPolicyBuilder();
+            builder.AddCustomFeature("push").None();
+            builder.AddCustomFeature("vibrate").All();
+
+            var result = builder.Build();
+
+            result.Should().Be("push=(), vibrate=*");
+        }
+
+        [Fact]
+        public void PermissionsPolicy_Build_AddingTheSameDirectiveTwice_OverwritesThePreviousCopy()
+        {
+            var builder = new PermissionsPolicyBuilder();
+            builder.AddAccelerometer().Self();
+            builder.AddAccelerometer().None();
+
+            var result = builder.Build();
+
+            result.Should().Be("accelerometer=()");
+        }
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -646,6 +647,121 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Test
                 var header = response.Headers.GetValues("Feature-Policy").FirstOrDefault();
                 header.Should().NotBeNull();
                 header.Should().Be("fullscreen 'self'; geolocation 'none'");
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithPermissionsPolicyHeader_SetsPermissionsPolicy()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddPermissionsPolicy(builder =>
+                            {
+                                builder.AddAccelerometer().Self().For("https://testurl1.com").For("https://testurl2.com").For("https://testurl3.com").For("https://testurl4.com");
+                                builder.AddFullscreen().Self();
+                                builder.AddAmbientLightSensor().For("https://testurl.com");
+                                builder.AddGeolocation().None();
+                                builder.AddCamera().All();
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Permissions-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("accelerometer=(self \"https://testurl1.com\" \"https://testurl2.com\" \"https://testurl3.com\" \"https://testurl4.com\"), fullscreen=self, ambient-light-sensor=\"https://testurl.com\", geolocation=(), camera=*");
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithPermissionsPolicyHeaderAndNotHtml_DoesNotSetPermissionsPolicy()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddPermissionsPolicy(builder =>
+                            {
+                                builder.AddFullscreen().Self();
+                                builder.AddGeolocation().None();
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/plain";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                response.Headers.Contains("Permissions-Policy").Should().BeFalse();
+            }
+        }
+
+
+        [Fact]
+        public async Task HttpRequest_WithPermissionsPolicyHeaderAndUnknonwnContentType_SetsPermissionsPolicyHeader()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddPermissionsPolicy(builder =>
+                            {
+                                builder.AddFullscreen().Self();
+                                builder.AddGeolocation().None();
+                            }));
+                    app.Run(async context =>
+                    {
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Permissions-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("fullscreen=self, geolocation=()");
             }
         }
 

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;


### PR DESCRIPTION
I essentially did a copy of the Feature-Policy folder content and renamed it.

The files where I did actual logical changes are:

- PermissionsPolicyDirectiveBuilder
- CustomPermissionsPolicyDirective (a bit uncertain about this one)

The logical changes that you can see in the PermissionsPolicyDirectiveBuilder were based off of the WC3 github repo information for [Permissions-Policy](https://github.com/w3c/webappsec-permissions-policy/blob/master/permissions-policy-explainer.md#new-header). I interpreted it that the current formats could be (please correct me here if I misunderstood):

`Permissions-Policy: camera=(), accelerometer=self, geolocation=*, gyroscope="https://gyros.com", fullscreen=(self "https://example.com" "https://another.example.com"), `

Beyond those changes, I copied the tests aswell and added a little bit more content to some, for example longer header values for a more complete picture of an end result.

I would very much appreciate feedback and further discussion if you want something changed/fixed.