### PR TITLE
Refactored CustomPermissionsPolicyDirective and cleaned up namespaces

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/CustomPermissionsPolicyDirective.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/CustomPermissionsPolicyDirective.cs
@@ -31,17 +31,12 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy
         /// <inheritdoc />
         internal override string Build()
         {
-            if (Value == "*")
-            {
-                return $"{Directive}={Value}";
-            }
-
             if (string.IsNullOrEmpty(Value))
             {
                 return $"{Directive}=()";
             }
 
-            return $"{Directive}=({Value})";
+            return $"{Directive}={Value}";
         }
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeaderExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Microsoft.AspNetCore.Builder;
 using NetEscapades.AspNetCore.SecurityHeaders.Headers;
 
-namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
+// ReSharper disable once CheckNamespace
+namespace Microsoft.AspNetCore.Builder
 {
     /// <summary>
     /// Extension methods for adding a <see cref="PermissionsPolicyHeader" /> to a <see cref="HeaderPolicyCollection" />

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PermissionsPolicyBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PermissionsPolicyBuilderTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Xunit;


### PR DESCRIPTION
Hello again @andrewlock !

My apologies, I missed two things that I feel I must rectify.

- I had misunderstood the CustomPermissionPolicyDirective. It is a single value, so I refactored the logic thereafter.

- I missed the extension namespace for the PermissionsPolicyHeaderExtensions, it is now the correct namespace for Microsoft.AspNetCore.Builder
