### PR TITLE
Added style-src 'report-sample' directive.

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
@@ -13,6 +13,16 @@
         }
 
         /// <summary>
+        /// Requires a sample of the violating code to be included in the violation report
+        /// </summary>
+        /// <returns>The CSP builder for method chaining</returns>
+        public StyleSourceDirectiveBuilder ReportSample()
+        {
+            Sources.Add("'report-sample'");
+            return this;
+        }
+
+        /// <summary>
         /// Allow sources for content generated using the the HashTagHelper.
         /// </summary>
         /// <returns>The CSP builder for method chaining</returns>

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
@@ -214,13 +214,14 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Test
             var builder = new CspBuilder();
             builder.AddStyleSrc()
                 .Self()
+                .ReportSample()
                 .Blob()
                 .Data()
                 .From("http://testUrl.com");
 
             var result = builder.Build();
 
-            result.ConstantValue.Should().Be("style-src 'self' blob: data: http://testUrl.com");
+            result.ConstantValue.Should().Be("style-src 'self' 'report-sample' blob: data: http://testUrl.com");
         }
 
         [Fact]


### PR DESCRIPTION
Added fluent 'ReportSample()' operations to the 'style-src' directive. Relates to item #89.