### PR TITLE
Added Cross-Origin-Opener-Policy (COOP) header implementation, base classes, tests

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginOpenerPolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginOpenerPolicyHeader.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
+{
+    /// <summary>
+    /// The header value to use for Cross-Origin-Opener-Policy
+    /// </summary>
+    public abstract class CrossOriginOpenerPolicyHeader : HtmlOnlyHeaderPolicyBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrossOriginOpenerPolicyHeader"/> class.
+        /// </summary>
+        /// <param name="reportOnly">If true, the Cross-Origin-Opener-Policy header is added as "Cross-Origin-Opener-Policy-Report-Only".</param>
+        protected CrossOriginOpenerPolicyHeader(bool reportOnly)
+        {
+            ReportOnly = reportOnly;
+        }
+
+        /// <inheritdoc />
+        public override string Header => ReportOnly ? "Cross-Origin-Opener-Policy-Report-Only" : "Cross-Origin-Opener-Policy";
+
+        /// <summary>
+        /// If true, the COOP header is added as "Cross-Origin-Opener-Policy-Report-Only".
+        /// If false, it's set to "Cross-Origin-Opener-Policy";
+        /// </summary>
+        internal bool ReportOnly { get; }
+
+        /// <summary>
+        /// Configure a Cross Origin Opener Policy
+        /// </summary>
+        /// <param name="configure">Configure the Cross Origin Opener Policy</param>
+        /// <param name="asReportOnly">If true, the header is added as report only</param>
+        /// <returns>The configured <see cref="CrossOriginOpenerPolicyHeader "/></returns>
+        public static CrossOriginOpenerPolicyHeader Build(Action<CrossOriginOpenerPolicyBuilder> configure, bool asReportOnly)
+        {
+            var builder = new CrossOriginOpenerPolicyBuilder();
+
+            configure(builder);
+
+            var coopResult = builder.Build();
+
+            return new StaticCrossOriginOpenerPolicyHeader(coopResult.ConstantValue, asReportOnly);
+        }
+
+        /// <summary>
+        /// A <see cref="CrossOriginOpenerPolicyHeader"/> which has a single static value
+        /// </summary>
+        public class StaticCrossOriginOpenerPolicyHeader : CrossOriginOpenerPolicyHeader
+        {
+            private readonly string _value;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CrossOriginOpenerPolicyHeader.StaticCrossOriginOpenerPolicyHeader"/> class.
+            /// </summary>
+            /// <param name="asReportOnly">If true, the header is added as report only</param>
+            /// <param name="value">The value to apply for the header</param>
+            public StaticCrossOriginOpenerPolicyHeader(string value, bool asReportOnly) : base(reportOnly: asReportOnly)
+            {
+                _value = value;
+            }
+
+            /// <inheritdoc />
+            protected override string GetValue(HttpContext context) => _value;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginOpenerPolicyHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginOpenerPolicyHeaderExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using NetEscapades.AspNetCore.SecurityHeaders.Headers;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Extension methods for adding a <see cref="CrossOriginOpenerPolicyHeader" /> to a <see cref="HeaderPolicyCollection" />
+    /// </summary>
+    public static class CrossOriginOpenerPolicyHeaderExtensions
+    {
+        /// <summary>
+        /// Add a Cross-Origin-Opener-Policy Header to all requests
+        /// </summary>
+        /// <param name="policies">The collection of policies</param>
+        /// <param name="configure">Configure the COOP</param>
+        /// <param name="asReportOnly">If true, the COOP header is addded as "Cross-Origin-Opener-Policy-Report-Only". If false, it's set to "Cross-Origin-Opener-Policy";</param>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
+        public static HeaderPolicyCollection AddCrossOriginOpenerPolicy(this HeaderPolicyCollection policies, Action<CrossOriginOpenerPolicyBuilder> configure, bool asReportOnly = false)
+        {
+            return policies.ApplyPolicy(CrossOriginOpenerPolicyHeader.Build(configure, asReportOnly));
+        }
+
+        /// <summary>
+        /// Add a Cross-Origin-Opener-Policy Header Report-Only to all requests
+        /// </summary>
+        /// <param name="policies">The collection of policies</param>
+        /// <param name="configure">Configure the COOP</param>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
+        public static HeaderPolicyCollection AddCrossOriginOpenerPolicyReportOnly(this HeaderPolicyCollection policies, Action<CrossOriginOpenerPolicyBuilder> configure)
+        {
+            return policies.ApplyPolicy(CrossOriginOpenerPolicyHeader.Build(configure, asReportOnly: true));
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/CrossOriginPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/CrossOriginPolicyBuilder.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Used to build a Cross Origin Policy header from multiple directives.
+    /// </summary>
+    public abstract class CrossOriginPolicyBuilder
+    {
+        private const string _directiveSeparator = "; ";
+
+        private readonly Dictionary<string, CrossOriginPolicyDirectiveBuilderBase> _directives =
+            new Dictionary<string, CrossOriginPolicyDirectiveBuilderBase>();
+
+        /// <summary>
+        /// The report-to directive instructs the user agent to report attempts to
+        /// violate the Cross Origin Policy. These violation reports consist of
+        /// JSON documents sent via an HTTP POST request to the specified URI.
+        /// </summary>
+        /// <returns>A configured <see cref="ReportDirectiveBuilder"/></returns>
+        public ReportDirectiveBuilder AddReport() => AddDirective(new ReportDirectiveBuilder());
+
+        /// <summary>
+        /// Adds a directive for the cross origin policy
+        /// </summary>
+        /// <typeparam name="T">The type of the directive</typeparam>
+        /// <param name="directive">The directive corresponding the the concrete implementation of the cross origin policy.</param>
+        /// <returns>A configured <see cref="CrossOriginPolicyDirectiveBuilderBase"/> implementation.</returns>
+        protected T AddDirective<T>(T directive) where T : CrossOriginPolicyDirectiveBuilderBase
+        {
+            _directives[directive.Directive] = directive;
+            return directive;
+        }
+
+        /// <summary>
+        /// Build the Cross Origin Policy directive
+        /// </summary>
+        /// <returns>The Cross Origin Policy directive as a string</returns>
+        internal CrossOriginPolicyBuilderResult Build()
+        {
+            // build the constant values ahead of time
+            var staticDirectives = _directives.Values
+                .Select(x => x.CreateBuilder().Invoke(null!))
+                .Where(x => !string.IsNullOrEmpty(x));
+
+            var constantDirective = string.Join(_directiveSeparator, staticDirectives);
+
+            return CrossOriginPolicyBuilderResult.CreateStaticResult(constantDirective);
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/CrossOriginPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/CrossOriginPolicyBuilder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// The report-to directive instructs the user agent to report attempts to
         /// violate the Cross Origin Policy. These violation reports consist of
-        /// JSON documents sent via an HTTP POST request to the specified URI.
+        /// JSON documents sent via an HTTP POST request to the specified reporting endpoint.
         /// </summary>
         /// <returns>A configured <see cref="ReportDirectiveBuilder"/></returns>
         public ReportDirectiveBuilder AddReport() => AddDirective(new ReportDirectiveBuilder());

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/CrossOriginPolicyBuilderResult.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/CrossOriginPolicyBuilderResult.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies
+{
+    /// <summary>
+    /// The output from calling <see cref="CrossOriginPolicyBuilder.Build"/>
+    /// </summary>
+    internal abstract class CrossOriginPolicyBuilderResult
+    {
+        /// <summary>
+        /// The Cross Origin Policy header value to use
+        /// </summary>
+        internal abstract string ConstantValue { get; }
+
+        /// <summary>
+        /// A builder function to generate the directives for a given request
+        /// </summary>
+        internal abstract Func<HttpContext, string> Builder { get; }
+
+        /// <summary>
+        /// Create a new <see cref="CrossOriginPolicyBuilderResult"/> with a constant value
+        /// </summary>
+        /// <param name="constantValue">The constant value to use for all requests</param>
+        /// <returns>The <see cref="CrossOriginPolicyBuilderResult"/></returns>
+        public static CrossOriginPolicyBuilderResult CreateStaticResult(string constantValue) =>
+            new StaticCrossOriginPolicyBuilderResult(constantValue);
+
+        /// <summary>
+        /// The output from calling <see cref="CrossOriginPolicyBuilder.Build"/>
+        /// </summary>
+        private class StaticCrossOriginPolicyBuilderResult : CrossOriginPolicyBuilderResult
+        {
+            private readonly string _constantValue;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CrossOriginPolicyBuilderResult.StaticCrossOriginPolicyBuilderResult"/> class.
+            /// </summary>
+            /// <param name="constantValue">The constant value to use for all requests</param>
+            public StaticCrossOriginPolicyBuilderResult(string constantValue) : base()
+            {
+                _constantValue = constantValue ?? throw new ArgumentNullException(nameof(constantValue));
+            }
+
+            /// <summary>
+            /// The Cross Origin  Policy header value to use
+            /// </summary>
+            internal override string ConstantValue => _constantValue;
+
+            /// <summary>
+            /// A builder function to generate the directives for a given request
+            /// </summary>
+            internal override Func<HttpContext, string> Builder =>
+                throw new InvalidOperationException("Cannot return dynamic builder: CrossOriginPolicyBuilderResult has constant value");
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/CrossOriginPolicyDirectiveBuilderBase.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/CrossOriginPolicyDirectiveBuilderBase.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies
+{
+    /// <summary>
+    /// Base class for building Cross Origin Policy directives.
+    /// </summary>
+    public abstract class CrossOriginPolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrossOriginPolicyDirectiveBuilderBase"/> class.
+        /// </summary>
+        /// <param name="directive">The name of the directive.</param>
+        protected CrossOriginPolicyDirectiveBuilderBase(string directive)
+        {
+            Directive = directive;
+        }
+
+        /// <summary>
+        /// The name of the directive.
+        /// </summary>
+        internal string Directive { get; }
+
+        /// <summary>
+        /// Create a builder function that can be invoked to find the directive's value
+        /// </summary>
+        /// <returns>A builder function for generating the directive's value</returns>
+        internal abstract Func<HttpContext, string> CreateBuilder();
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/OpenerPolicy/CrossOriginOpenerPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/OpenerPolicy/CrossOriginOpenerPolicyBuilder.cs
@@ -1,0 +1,35 @@
+﻿// ReSharper disable once CheckNamespace
+using NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies.OpenerPolicy;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Used to build a Cross Origin Opener Policy header from multiple directives.
+    /// </summary>
+    public class CrossOriginOpenerPolicyBuilder : CrossOriginPolicyBuilder
+    {
+        /// <summary>
+        /// This is the default value. Allows the document to be added to its opener's browsing context
+        /// group unless the opener itself has a COOP of same-origin or same-origin-allow-popups.
+        /// From: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy#directives
+        /// </summary>
+        /// <returns>A configured <see cref="UnsafeNoneDirectiveBuilder"/></returns>
+        public UnsafeNoneDirectiveBuilder UnsafeNone() => AddDirective(new UnsafeNoneDirectiveBuilder());
+
+        /// <summary>
+        /// Isolates the browsing context exclusively to same-origin documents.
+        /// Cross-origin documents are not loaded in the same browsing context.
+        /// From: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy#directives
+        /// </summary>
+        /// <returns>A configured <see cref="SameOriginDirectiveBuilder"/></returns>
+        public SameOriginDirectiveBuilder SameOrigin() => AddDirective(new SameOriginDirectiveBuilder());
+
+        /// <summary>
+        /// Retains references to newly opened windows or tabs which either don't set COOP or which opt out
+        /// of isolation by setting a COOP of unsafe-none.
+        /// From: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy#directives
+        /// </summary>
+        /// <returns>A configured <see cref="SameOriginAllowPopupsDirectiveBuilder"/></returns>
+        public SameOriginAllowPopupsDirectiveBuilder SameOriginAllowPopups() => AddDirective(new SameOriginAllowPopupsDirectiveBuilder());
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/OpenerPolicy/CrossOriginOpenerPolicyDirectiveBuilderBase.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/OpenerPolicy/CrossOriginOpenerPolicyDirectiveBuilderBase.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies.OpenerPolicy
+{
+    /// <summary>
+    /// grfr
+    /// </summary>
+    public abstract class CrossOriginOpenerPolicyDirectiveBuilderBase : CrossOriginPolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrossOriginOpenerPolicyDirectiveBuilderBase"/> class.
+        /// </summary>
+        /// <param name="directive">The name of the directive</param>
+        protected CrossOriginOpenerPolicyDirectiveBuilderBase(string directive) : base(directive)
+        {
+        }
+
+        /// <inheritdoc />
+        internal override abstract Func<HttpContext, string> CreateBuilder();
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/OpenerPolicy/SameOriginAllowPopupsDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/OpenerPolicy/SameOriginAllowPopupsDirectiveBuilder.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies.OpenerPolicy
+{
+    /// <summary>
+    /// Retains references to newly opened windows or tabs which either don't set COOP or which opt out
+    /// of isolation by setting a COOP of unsafe-none.
+    /// From: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy#directives
+    /// </summary>
+    public class SameOriginAllowPopupsDirectiveBuilder : CrossOriginOpenerPolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SameOriginAllowPopupsDirectiveBuilder"/> class.
+        /// </summary>
+        public SameOriginAllowPopupsDirectiveBuilder() : base("same-origin-allow-popups")
+        {
+        }
+
+        /// <inheritdoc />
+        internal override Func<HttpContext, string> CreateBuilder()
+        {
+            return ctx => Directive;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/OpenerPolicy/SameOriginDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/OpenerPolicy/SameOriginDirectiveBuilder.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies.OpenerPolicy
+{
+    /// <summary>
+    /// Isolates the browsing context exclusively to same-origin documents.
+    /// Cross-origin documents are not loaded in the same browsing context.
+    /// From: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy#directives
+    /// </summary>
+    public class SameOriginDirectiveBuilder : CrossOriginOpenerPolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SameOriginDirectiveBuilder"/> class.
+        /// </summary>
+        public SameOriginDirectiveBuilder() : base("same-origin")
+        {
+        }
+
+        /// <inheritdoc />
+        internal override Func<HttpContext, string> CreateBuilder()
+        {
+            return ctx => Directive;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/OpenerPolicy/UnsafeNoneDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/OpenerPolicy/UnsafeNoneDirectiveBuilder.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies.OpenerPolicy
+{
+    /// <summary>
+    /// This is the default value. Allows the document to be added to its opener's browsing context
+    /// group unless the opener itself has a COOP of same-origin or same-origin-allow-popups.
+    /// From: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy#directives
+    /// </summary>
+    public class UnsafeNoneDirectiveBuilder : CrossOriginOpenerPolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnsafeNoneDirectiveBuilder"/> class.
+        /// </summary>
+        public UnsafeNoneDirectiveBuilder() : base("unsafe-none")
+        {
+        }
+
+        /// <inheritdoc />
+        internal override Func<HttpContext, string> CreateBuilder()
+        {
+            return ctx => Directive;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ReportDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ReportDirectiveBuilder.cs
@@ -4,9 +4,9 @@ using Microsoft.AspNetCore.Http;
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies
 {
     /// <summary>
-    /// The report-uri directive instructs the user agent to report attempts to
+    /// The report-to directive instructs the user agent to report attempts to
     /// violate the Cross Origin Policy. These violation reports consist of
-    /// JSON documents sent via an HTTP POST request to the specified URI.
+    /// JSON documents sent via an HTTP POST request to the specified reporting endpoint.
     /// </summary>
     public class ReportDirectiveBuilder : CrossOriginPolicyDirectiveBuilderBase
     {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ReportDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ReportDirectiveBuilder.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies
+{
+    /// <summary>
+    /// The report-uri directive instructs the user agent to report attempts to
+    /// violate the Cross Origin Policy. These violation reports consist of
+    /// JSON documents sent via an HTTP POST request to the specified URI.
+    /// </summary>
+    public class ReportDirectiveBuilder : CrossOriginPolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReportDirectiveBuilder"/> class.
+        /// </summary>
+        public ReportDirectiveBuilder() : base("report-to")
+        {
+            Endpoint = string.Empty;
+        }
+
+        private string Endpoint { get; set; }
+
+        /// <inheritdoc />
+        internal override Func<HttpContext, string> CreateBuilder()
+        {
+            if (string.IsNullOrEmpty(Endpoint))
+            {
+                // TODO warn they added a report uri but no uri
+                return ctx => string.Empty;
+            }
+
+            return ctx => $"{Directive}=\"{Endpoint}\"";
+        }
+
+        /// <summary>
+        /// Sets the reporting endpoint to post the report to.
+        /// </summary>
+        /// <param name="endpoint">The reporting endpoint to post the report to.</param>
+        /// <returns>A configured ReportDirectiveBuilder object.</returns>
+        public CrossOriginPolicyDirectiveBuilderBase To(string endpoint)
+        {
+            if (string.IsNullOrWhiteSpace(endpoint))
+            {
+                throw new System.ArgumentException("Endpoint may not be null or empty", nameof(endpoint));
+            }
+
+            Endpoint = endpoint;
+            return this;
+        }
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CrossOriginOpenerPolicyBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CrossOriginOpenerPolicyBuilderTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Test
+{
+    public class CrossOriginOpenerPolicyBuilderTests
+    {
+        [Fact]
+        public void Build_WhenNoValues_ReturnsNullValue()
+        {
+            var builder = new CrossOriginOpenerPolicyBuilder();
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void Build_AddUnsafeNone_AddsValue()
+        {
+            var builder = new CrossOriginOpenerPolicyBuilder();
+            builder.UnsafeNone();
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("unsafe-none");
+        }
+
+        [Fact]
+        public void Build_AddUnsafeNone_WithReportEndpoint_AddsValue()
+        {
+            var builder = new CrossOriginOpenerPolicyBuilder();
+            builder.UnsafeNone();
+            builder.AddReport().To("default");
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("unsafe-none; report-to=\"default\"");
+        }
+
+        [Fact]
+        public void Build_AddSameOrigin_AddsValue()
+        {
+            var builder = new CrossOriginOpenerPolicyBuilder();
+            builder.SameOrigin();
+            
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("same-origin");
+        }
+
+        [Fact]
+        public void Build_AddSameOrigin_WithReportEndpoint_AddsValue()
+        {
+            var builder = new CrossOriginOpenerPolicyBuilder();
+            builder.SameOrigin();
+            builder.AddReport().To("default");
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("same-origin; report-to=\"default\"");
+        }
+
+        [Fact]
+        public void Build_AddSameOriginAllowPopups_AddsValue()
+        {
+            var builder = new CrossOriginOpenerPolicyBuilder();
+            builder.SameOriginAllowPopups();
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("same-origin-allow-popups");
+        }
+
+        [Fact]
+        public void Build_AddSameOriginAllowPopups_WithReportEndpoint_AddsValue()
+        {
+            var builder = new CrossOriginOpenerPolicyBuilder();
+            builder.SameOriginAllowPopups();
+            builder.AddReport().To("default");
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("same-origin-allow-popups; report-to=\"default\"");
+        }
+    }
+}


### PR DESCRIPTION
Pull-request for part of #103 - adding Cross-Origin-Opener-Policy (COOP) header implementation.

Notes:
- Built code to be similar to existing CSP pattern for consistency across the codebase.

- Created "CrossOriginPolicy" base classes for re-use across COOP/COEP/CORP header implementations.

Implementation can be used in a HeaderPolicyCollection like so:
```
var policyCollection = new HeaderPolicyCollection()
.AddCrossOriginOpenerPolicy(builder =>
{
    builder.SameOrigin();
    builder.AddReport().To("default");
});

```
If this implementation meets review standards, I'll create separate smaller pull requests for the COEP and CORP headers to close off this feature request.

Thanks!
Jeremy