### PR TITLE
Added Cross-Origin-Resource-Policy header

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ResourcePolicy/CrossOriginDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ResourcePolicy/CrossOriginDirectiveBuilder.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies.ResourcePolicy
+{
+    /// <summary>
+    /// Allows resources to be loaded from other domains.
+    /// </summary>
+    public class CrossOriginDirectiveBuilder : CrossOriginResourcePolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrossOriginDirectiveBuilder"/> class.
+        /// </summary>
+        public CrossOriginDirectiveBuilder() : base("cross-origin")
+        {
+        }
+
+        /// <inheritdoc />
+        internal override Func<HttpContext, string> CreateBuilder()
+        {
+            return ctx => Directive;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ResourcePolicy/CrossOriginResourcePolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ResourcePolicy/CrossOriginResourcePolicyBuilder.cs
@@ -1,0 +1,29 @@
+﻿// ReSharper disable once CheckNamespace
+using NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies.ResourcePolicy;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Used to build a Cross Origin Resource Policy header from multiple directives.
+    /// </summary>
+    public class CrossOriginResourcePolicyBuilder : CrossOriginPolicyBuilder
+    {
+        /// <summary>
+        /// More relaxed setting - only allow resources to be loaded from the same domain and sub-domains.
+        /// </summary>
+        /// <returns>A configured <see cref="SameSiteDirectiveBuilder"/></returns>
+        public SameSiteDirectiveBuilder SameSite() => AddDirective(new SameSiteDirectiveBuilder());
+
+        /// <summary>
+        /// Most strict setting - only allow resources to be loaded from the same origin.
+        /// </summary>
+        /// <returns>A configured <see cref="SameOriginDirectiveBuilder"/></returns>
+        public SameOriginDirectiveBuilder SameOrigin() => AddDirective(new SameOriginDirectiveBuilder());
+
+        /// <summary>
+        /// Allows resources to be loaded from other domains.
+        /// </summary>
+        /// <returns>A configured <see cref="CrossOriginDirectiveBuilder"/></returns>
+        public CrossOriginDirectiveBuilder CrossOrigin() => AddDirective(new CrossOriginDirectiveBuilder());
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ResourcePolicy/CrossOriginResourcePolicyDirectiveBuilderBase.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ResourcePolicy/CrossOriginResourcePolicyDirectiveBuilderBase.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies.ResourcePolicy
+{
+    /// <summary>
+    /// The Cross Origin Resource Policy directive builder base class
+    /// </summary>
+    public abstract class CrossOriginResourcePolicyDirectiveBuilderBase : CrossOriginPolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrossOriginResourcePolicyDirectiveBuilderBase"/> class.
+        /// </summary>
+        /// <param name="directive">tfe</param>
+        protected CrossOriginResourcePolicyDirectiveBuilderBase(string directive) : base(directive)
+        {
+        }
+
+        /// <inheritdoc />
+        internal override abstract Func<HttpContext, string> CreateBuilder();
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ResourcePolicy/SameOriginDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ResourcePolicy/SameOriginDirectiveBuilder.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies.ResourcePolicy
+{
+    /// <summary>
+    /// Most strict setting - only allow resources to be loaded from the same origin.
+    /// </summary>
+    public class SameOriginDirectiveBuilder : CrossOriginResourcePolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SameOriginDirectiveBuilder"/> class.
+        /// </summary>
+        public SameOriginDirectiveBuilder() : base("same-origin")
+        {
+        }
+
+        /// <inheritdoc />
+        internal override Func<HttpContext, string> CreateBuilder()
+        {
+            return ctx => Directive;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ResourcePolicy/SameSiteDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/ResourcePolicy/SameSiteDirectiveBuilder.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.CrossOriginPolicies.ResourcePolicy
+{
+    /// <summary>
+    /// More relaxed setting - only allow resources to be loaded from the same domain and sub-domains.
+    /// </summary>
+    public class SameSiteDirectiveBuilder : CrossOriginResourcePolicyDirectiveBuilderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SameSiteDirectiveBuilder"/> class.
+        /// </summary>
+        public SameSiteDirectiveBuilder() : base("same-site")
+        {
+        }
+
+        /// <inheritdoc />
+        internal override Func<HttpContext, string> CreateBuilder()
+        {
+            return ctx => Directive;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginResourcePolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginResourcePolicyHeader.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
+{
+    /// <summary>
+    /// The header value to use for Cross-Origin-Resource-Policy
+    /// </summary>
+    public abstract class CrossOriginResourcePolicyHeader : HtmlOnlyHeaderPolicyBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrossOriginResourcePolicyHeader"/> class.
+        /// </summary>
+        protected CrossOriginResourcePolicyHeader()
+        {
+        }
+
+        /// <inheritdoc />
+        public override string Header => "Cross-Origin-Resource-Policy";
+
+        /// <summary>
+        /// Configure a Cross Origin Resource Policy
+        /// </summary>
+        /// <param name="configure">Configure the Cross Origin Resource Policy</param>
+        /// <returns>The configured <see cref="CrossOriginResourcePolicyHeader "/></returns>
+        public static CrossOriginResourcePolicyHeader Build(Action<CrossOriginResourcePolicyBuilder> configure)
+        {
+            var builder = new CrossOriginResourcePolicyBuilder();
+
+            configure(builder);
+
+            var coopResult = builder.Build();
+
+            return new StaticCrossOriginResourcePolicyHeader(coopResult.ConstantValue);
+        }
+
+        /// <summary>
+        /// A <see cref="CrossOriginResourcePolicyHeader"/> which has a single static value
+        /// </summary>
+        public class StaticCrossOriginResourcePolicyHeader : CrossOriginResourcePolicyHeader
+        {
+            private readonly string _value;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CrossOriginResourcePolicyHeader.StaticCrossOriginResourcePolicyHeader"/> class.
+            /// </summary>
+            /// <param name="value">The value to apply for the header</param>
+            public StaticCrossOriginResourcePolicyHeader(string value) : base()
+            {
+                _value = value;
+            }
+
+            /// <inheritdoc />
+            protected override string GetValue(HttpContext context) => _value;
+        }
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginResourcePolicyHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginResourcePolicyHeaderExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using NetEscapades.AspNetCore.SecurityHeaders.Headers;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Extension methods for adding a <see cref="CrossOriginResourcePolicyHeader" /> to a <see cref="HeaderPolicyCollection" />
+    /// </summary>
+    public static class CrossOriginResourcePolicyHeaderExtensions
+    {
+        /// <summary>
+        /// Add a Cross-Origin-Resource-Policy Header to all requests
+        /// </summary>
+        /// <param name="policies">The collection of policies</param>
+        /// <param name="configure">Configure the CORP</param>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
+        public static HeaderPolicyCollection AddCrossOriginResourcePolicy(this HeaderPolicyCollection policies, Action<CrossOriginResourcePolicyBuilder> configure)
+        {
+            return policies.ApplyPolicy(CrossOriginResourcePolicyHeader.Build(configure));
+        }
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CrossOriginResourcePolicyBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CrossOriginResourcePolicyBuilderTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Test
+{
+    public class CrossOriginResourcePolicyBuilderTests
+    {
+        [Fact]
+        public void Build_WhenNoValues_ReturnsNullValue()
+        {
+            var builder = new CrossOriginResourcePolicyBuilder();
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void Build_AddSameSite_AddsValue()
+        {
+            var builder = new CrossOriginResourcePolicyBuilder();
+            builder.SameSite();
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("same-site");
+        }
+
+        [Fact]
+        public void Build_AddSameSite_WithReportEndpoint_AddsValue()
+        {
+            var builder = new CrossOriginResourcePolicyBuilder();
+            builder.SameSite();
+            builder.AddReport().To("default");
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("same-site; report-to=\"default\"");
+        }
+
+        [Fact]
+        public void Build_AddSameOrigin_AddsValue()
+        {
+            var builder = new CrossOriginResourcePolicyBuilder();
+            builder.SameOrigin();
+            
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("same-origin");
+        }
+
+        [Fact]
+        public void Build_AddSameOrigin_WithReportEndpoint_AddsValue()
+        {
+            var builder = new CrossOriginResourcePolicyBuilder();
+            builder.SameOrigin();
+            builder.AddReport().To("default");
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("same-origin; report-to=\"default\"");
+        }
+
+        [Fact]
+        public void Build_AddCrossOrigin_AddsValue()
+        {
+            var builder = new CrossOriginResourcePolicyBuilder();
+            builder.CrossOrigin();
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("cross-origin");
+        }
+
+        [Fact]
+        public void Build_AddCrossOrigin_WithReportEndpoint_AddsValue()
+        {
+            var builder = new CrossOriginResourcePolicyBuilder();
+            builder.CrossOrigin();
+            builder.AddReport().To("default");
+
+            var result = builder.Build();
+
+            result.ConstantValue.Should().Be("cross-origin; report-to=\"default\"");
+        }
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -1129,6 +1129,544 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Test
             }
         }
 
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginOpenerPolicyHeader_SetsUnsafeNone()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginOpenerPolicy(builder =>
+                            {
+                                builder.UnsafeNone();
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Opener-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("unsafe-none");
+                response.Headers.Contains("Cross-Origin-Opener-Policy-Report-Only").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginOpenerPolicyHeader_SetsUnsafeNone_WithReportingEndpoint()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginOpenerPolicy(builder =>
+                            {
+                                builder.UnsafeNone();
+                                builder.AddReport().To("coop_endpoint");
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Opener-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("unsafe-none; report-to=\"coop_endpoint\"");
+                response.Headers.Contains("Cross-Origin-Opener-Policy-Report-Only").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginOpenerPolicyHeader_SetsSameOrigin()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginOpenerPolicy(builder =>
+                            {
+                                builder.SameOrigin();
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Opener-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("same-origin");
+                response.Headers.Contains("Cross-Origin-Opener-Policy-Report-Only").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginOpenerPolicyHeader_SetsSameOriginAllowPopups()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginOpenerPolicy(builder =>
+                            {
+                                builder.SameOriginAllowPopups();
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Opener-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("same-origin-allow-popups");
+                response.Headers.Contains("Cross-Origin-Opener-Policy-Report-Only").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginEmbedderPolicyHeader_SetsUnsafeNone()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginEmbedderPolicy(builder =>
+                            {
+                                builder.UnsafeNone();
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Embedder-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("unsafe-none");
+                response.Headers.Contains("Cross-Origin-Embedder-Policy-Report-Only").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginEmbedderPolicyHeader_SetsRequireCorp()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginEmbedderPolicy(builder =>
+                            {
+                                builder.RequireCorp();
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Embedder-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("require-corp");
+                response.Headers.Contains("Cross-Origin-Embedder-Policy-Report-Only").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginResourcePolicyHeader_SetsSameSite()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginResourcePolicy(builder =>
+                            {
+                                builder.SameSite();
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Resource-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("same-site");
+                response.Headers.Contains("Cross-Origin-Resource-Policy-Report-Only").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginResourcePolicyHeader_SetsSameOrigin()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginResourcePolicy(builder =>
+                            {
+                                builder.SameOrigin();
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Resource-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("same-origin");
+                response.Headers.Contains("Cross-Origin-Resource-Policy-Report-Only").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginResourcePolicyHeader_SetsCrossOrigin()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginResourcePolicy(builder =>
+                            {
+                                builder.CrossOrigin();
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Resource-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("cross-origin");
+                response.Headers.Contains("Cross-Origin-Resource-Policy-Report-Only").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginOpenerPolicyHeaderReportOnly_SetsUnsafeNone()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginOpenerPolicyReportOnly(builder =>
+                            {
+                                builder.UnsafeNone();
+                                builder.AddReport().To("coop_endpoint");
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Opener-Policy-Report-Only").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("unsafe-none; report-to=\"coop_endpoint\"");
+                response.Headers.Contains("Cross-Origin-Opener-Policy").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginOpenerPolicyHeaderReportOnly_UsingBoolean_SetsUnsafeNone()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginOpenerPolicy(builder =>
+                            {
+                                builder.UnsafeNone();
+                                builder.AddReport().To("coop_endpoint");
+                            }, asReportOnly: true));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Opener-Policy-Report-Only").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("unsafe-none; report-to=\"coop_endpoint\"");
+                response.Headers.Contains("Cross-Origin-Opener-Policy").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginOpenerPolicyHeader_UsingBooleanAsFalse_SetsUnsafeNone()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginOpenerPolicy(builder =>
+                            {
+                                builder.UnsafeNone();
+                                builder.AddReport().To("coop_endpoint");
+                            }, asReportOnly: false));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Opener-Policy").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("unsafe-none; report-to=\"coop_endpoint\"");
+                response.Headers.Contains("Cross-Origin-Opener-Policy-Report-Only").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginEmbedderPolicyHeaderReportOnly_SetsUnsafeNone()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginEmbedderPolicyReportOnly(builder =>
+                            {
+                                builder.UnsafeNone();
+                                builder.AddReport().To("coep_endpoint");
+                            }));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Embedder-Policy-Report-Only").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("unsafe-none; report-to=\"coep_endpoint\"");
+                response.Headers.Contains("Cross-Origin-Embedder-Policy").Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public async Task HttpRequest_WithCrossOriginEmbedderPolicyHeaderReportOnly_UsingBoolean_SetsUnsafeNone()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(
+                        new HeaderPolicyCollection()
+                            .AddCrossOriginEmbedderPolicy(builder =>
+                            {
+                                builder.UnsafeNone();
+                                builder.AddReport().To("coep_endpoint");
+                            }, asReportOnly: true));
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                var response = await server.CreateRequest("/")
+                    .SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("Cross-Origin-Embedder-Policy-Report-Only").FirstOrDefault();
+                header.Should().NotBeNull();
+                header.Should().Be("unsafe-none; report-to=\"coep_endpoint\"");
+                response.Headers.Contains("Cross-Origin-Embedder-Policy").Should().BeFalse();
+            }
+        }
+
         private static void AssertHttpRequestDefaultSecurityHeaders(HttpResponseHeaders headers)
         {
             string header = headers.GetValues("X-Content-Type-Options").FirstOrDefault();


### PR DESCRIPTION
Last of three pull-requests to close #103 - this time, adding Cross-Origin-Resource-Policy (CORP) header implementation.

Implementation can be used in a HeaderPolicyCollection like so:

```
var policyCollection = new HeaderPolicyCollection()
.AddCrossOriginResourcePolicy(builder =>
{
    builder.SameSite();
    builder.AddReport().To("default");
});
```

No report only option this time as I can't find any citations online of its use (unlike COOP and COEP). However if this turns out to be needed, it should be very easy to add this through the CrossOriginResourcePolicyHeader class.

Related to pull-request #104.

I think that's it for this feature request!