### PR TITLE
Add support for X-Permitted-Cross-Domain-Policies header

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.Builder
             policies.AddContentTypeOptionsNoSniff();
             policies.AddStrictTransportSecurityMaxAge();
             policies.AddReferrerPolicyStrictOriginWhenCrossOrigin();
+            policies.AddPermittedCrossDomainPoliciesNone();
             policies.RemoveServerHeader();
             policies.AddContentSecurityPolicy(builder =>
             {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermittedCrossDomainPoliciesHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermittedCrossDomainPoliciesHeader.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
+{
+    /// <summary>
+    /// The header value to use for X-Permitted-Cross-Domain-Policies
+    /// </summary>
+    public class PermittedCrossDomainPoliciesHeader : HtmlOnlyHeaderPolicyBase
+    {
+        private readonly string _value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PermittedCrossDomainPoliciesHeader"/> class.
+        /// </summary>
+        /// <param name="value">The value to apply for the header</param>
+        public PermittedCrossDomainPoliciesHeader(string value)
+        {
+            _value = value;
+        }
+
+        /// <inheritdoc />
+        public override string Header { get; } = "X-Permitted-Cross-Domain-Policies";
+
+        /// <inheritdoc />
+        protected override string GetValue(HttpContext context) => _value;
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermittedCrossDomainPoliciesHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermittedCrossDomainPoliciesHeaderExtensions.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Builder;
+using NetEscapades.AspNetCore.SecurityHeaders.Headers;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Extension methods for adding a <see cref="PermittedCrossDomainPoliciesHeader" /> to a <see cref="HeaderPolicyCollection" />
+    /// </summary>
+    public static class PermittedCrossDomainPoliciesHeaderExtensions
+    {
+        /// <summary>
+        /// Add X-Permitted-Cross-Domain-Policies none to all requests.
+        /// Disables PDF and Flash embedding.
+        /// </summary>
+        /// <param name="policies">The collection of policies</param>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
+        public static HeaderPolicyCollection AddPermittedCrossDomainPoliciesNone(this HeaderPolicyCollection policies)
+        {
+            return policies.ApplyPolicy(new PermittedCrossDomainPoliciesHeader("none"));
+        }
+
+        /// <summary>
+        /// Add X-Permitted-Cross-Domain-Policies master-only to all requests.
+        /// Disables PDF and Flash embedding but allows the /crossdomain.xml.
+        /// </summary>
+        /// <param name="policies">The collection of policies</param>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
+        public static HeaderPolicyCollection AddPermittedCrossDomainPoliciesMasterOnly(this HeaderPolicyCollection policies)
+        {
+            return policies.ApplyPolicy(new PermittedCrossDomainPoliciesHeader("master-only"));
+        }
+
+        /// <summary>
+        /// Add X-Permitted-Cross-Domain-Policies by-content-type to all requests.
+        /// Disables PDF and Flash embedding but allows the files with the content type "text/x-cross-domain-policy".
+        /// </summary>
+        /// <param name="policies">The collection of policies</param>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
+        public static HeaderPolicyCollection AddPermittedCrossDomainPoliciesByContentType(this HeaderPolicyCollection policies)
+        {
+            return policies.ApplyPolicy(new PermittedCrossDomainPoliciesHeader("by-content-type"));
+        }
+
+        /// <summary>
+        /// Add X-Permitted-Cross-Domain-Policies none to all requests.
+        /// Allows PDF and Flash embedding for all policy files.
+        /// </summary>
+        /// <param name="policies">The collection of policies</param>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
+        public static HeaderPolicyCollection AddPermittedCrossDomainPoliciesAll(this HeaderPolicyCollection policies)
+        {
+            return policies.ApplyPolicy(new PermittedCrossDomainPoliciesHeader("all"));
+        }
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -1667,6 +1667,134 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Test
             }
         }
 
+        [Fact]
+        public async Task SecureRequest_PermittedCrossDomainPolicies_WithNone_IsCorrect()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .UseUrls("https://example.com:5001")
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(p => p.AddPermittedCrossDomainPoliciesNone());
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                server.BaseAddress = new Uri("https://example.com:5001");
+                var response = await server.CreateRequest("/").SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("X-Permitted-Cross-Domain-Policies").FirstOrDefault();
+                header.Should().Be("none");
+            }
+        }
+
+        [Fact]
+        public async Task SecureRequest_PermittedCrossDomainPolicies_WithMasterOnly_IsCorrect()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .UseUrls("https://example.com:5001")
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(p => p.AddPermittedCrossDomainPoliciesMasterOnly());
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                server.BaseAddress = new Uri("https://example.com:5001");
+                var response = await server.CreateRequest("/").SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("X-Permitted-Cross-Domain-Policies").FirstOrDefault();
+                header.Should().Be("master-only");
+            }
+        }
+
+        [Fact]
+        public async Task SecureRequest_PermittedCrossDomainPolicies_WithByContentType_IsCorrect()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .UseUrls("https://example.com:5001")
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(p => p.AddPermittedCrossDomainPoliciesByContentType());
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                server.BaseAddress = new Uri("https://example.com:5001");
+                var response = await server.CreateRequest("/").SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("X-Permitted-Cross-Domain-Policies").FirstOrDefault();
+                header.Should().Be("by-content-type");
+            }
+        }
+
+        [Fact]
+        public async Task SecureRequest_PermittedCrossDomainPolicies_WithAll_IsCorrect()
+        {
+            // Arrange
+            var hostBuilder = new WebHostBuilder()
+                .UseUrls("https://example.com:5001")
+                .Configure(app =>
+                {
+                    app.UseSecurityHeaders(p => p.AddPermittedCrossDomainPoliciesAll());
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+
+            using (var server = new TestServer(hostBuilder))
+            {
+                // Act
+                // Actual request.
+                server.BaseAddress = new Uri("https://example.com:5001");
+                var response = await server.CreateRequest("/").SendAsync("PUT");
+
+                // Assert
+                response.EnsureSuccessStatusCode();
+
+                (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+                var header = response.Headers.GetValues("X-Permitted-Cross-Domain-Policies").FirstOrDefault();
+                header.Should().Be("all");
+            }
+        }
+
         private static void AssertHttpRequestDefaultSecurityHeaders(HttpResponseHeaders headers)
         {
             string header = headers.GetValues("X-Content-Type-Options").FirstOrDefault();
@@ -1679,6 +1807,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Test
             header.Should().Be("strict-origin-when-cross-origin");
             header = headers.GetValues("Content-Security-Policy").FirstOrDefault();
             header.Should().Be("object-src 'none'; form-action 'self'; frame-ancestors 'none'");
+            header = headers.GetValues("X-Permitted-Cross-Domain-Policies").FirstOrDefault();
+            header.Should().Be("none");
 
             Assert.False(headers.Contains("Server"),
                 "Should not contain server header");
@@ -1700,6 +1830,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Test
             header.Should().Be("strict-origin-when-cross-origin");
             header = headers.GetValues("Content-Security-Policy").FirstOrDefault();
             header.Should().Be("object-src 'none'; form-action 'self'; frame-ancestors 'none'");
+            header = headers.GetValues("X-Permitted-Cross-Domain-Policies").FirstOrDefault();
+            header.Should().Be("none");
 
             Assert.False(headers.Contains("Server"),
                 "Should not contain server header");


### PR DESCRIPTION
This PR adds two things:
- New extensions to set the following values for `X-Permitted-Cross-Domain-Policies`: `none`, `master-only`, `by-content-type`and `all`
- Set that header to `none`when using the default security headers.

Reasoning: This header is listed in the [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/) as a header that should be taken care of. According to their [Best Practices](https://owasp.org/www-project-secure-headers/#div-bestpractices), it should be set to `none`

The other possible header values I got from here: https://arminreiter.com/2020/10/website-hardening-with-http-security-headers/

Apparently, this header is used by Flash and other Adobe products to handle cross site requests. Something you do not want unless explicitly supported.