### PR TITLE
Fix header being generated on every request when caching is enabled.

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
@@ -82,7 +82,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
         private Task CleanUpHeaders(object state)
         {
             var context = (HttpContext)state;
-            if (!context.Response.ContentType.StartsWith("text/html"))
+            if (!context.Response.ContentType?.StartsWith("text/html") ?? false)
             {
                 var headers = context.Response.Headers;
                 foreach (var header in _htmlOnlyHeaders)

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
@@ -64,25 +64,9 @@ namespace NetEscapades.AspNetCore.SecurityHeaders
                 context.SetNonce(_nonceGenerator.GetNonce(Constants.DefaultBytesInNonce));
             }
 
-            context.Response.OnStarting(OnResponseStarting, Tuple.Create(this, context, _policy));
+            var result = CustomHeaderService.EvaluatePolicy(context, _policy);
+            CustomHeaderService.ApplyResult(context.Response, result);
             await _next(context);
-        }
-
-        private static Task OnResponseStarting(object state)
-        {
-            var tuple = (Tuple<SecurityHeadersMiddleware, HttpContext, HeaderPolicyCollection>)state;
-            var middleware = tuple.Item1;
-            var context = tuple.Item2;
-            var policy = tuple.Item3;
-
-            var result = middleware.CustomHeaderService.EvaluatePolicy(context, policy);
-            middleware.CustomHeaderService.ApplyResult(context.Response, result);
-
-#if NET451
-            return Task.FromResult(true);
-#else
-            return Task.CompletedTask;
-#endif
         }
 
         private static bool MustGenerateNonce(HeaderPolicyCollection policy)


### PR DESCRIPTION
Adds test case for using response caching middleware and addresses the timing issue in the middleware.  This also has the added benefit of one less allocation per request.

Resolves #117