### PR TITLE
Optionally apply html headers to all document headers

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollection.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NetEscapades.AspNetCore.SecurityHeaders.Headers;
 
 // ReSharper disable once CheckNamespace
@@ -9,5 +10,45 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public class HeaderPolicyCollection : Dictionary<string, IHeaderPolicy>
     {
+        /// <summary>
+        /// The content types that document-based headers such as Content-Security-Policy should apply to
+        /// </summary>
+        internal string[]? DocumentHeaderContentTypePrefixes { get; set; } = { "text/html", "application/javascript" };
+
+        /// <summary>
+        /// Apply document-based headers such as Content-Security-Policy to all responses serving the provided
+        /// content-type prefixes.
+        /// </summary>
+        /// <param name="contentTypes">The content-type response prefixes to apply the headers to. For example, using
+        /// <c>new [] { "text/" }</c> would cause all document-based headers to be applied only to responses
+        /// returning content-types such as <c>"text/plain"</c>, or <c>"text/html"</c></param>
+        /// <remarks>Generally, headers such as Content-Security-Policy only make sense at the document level, so
+        /// they are typically only applied to HTML documents, and to JavaScript (web workers have their own
+        /// policy, <see cref="!:https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#content_security_policy" >MDN</see>
+        /// for details). However, in some cases, you may want to apply your document headers to additional
+        /// content-types.</remarks>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> for chaining</returns>
+        public HeaderPolicyCollection ApplyDocumentHeadersToContentTypes(string[] contentTypes)
+        {
+            DocumentHeaderContentTypePrefixes = contentTypes ?? throw new ArgumentNullException(nameof(contentTypes));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Apply document-based headers such as Content-Security-Policy to all responses, regardless of content-type.
+        /// </summary>
+        /// <remarks>Generally, headers such as Content-Security-Policy only make sense at the document level, so
+        /// they are typically only applied to HTML documents, and to JavaScript (web workers have their own
+        /// policy, <see cref="!:https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#content_security_policy" >MDN</see>
+        /// for details). However, in some cases, you may want to apply your document headers to additional
+        /// content-types.</remarks>
+        /// <returns>The <see cref="HeaderPolicyCollection"/> for chaining</returns>
+        public HeaderPolicyCollection ApplyDocumentHeadersToAllResponses()
+        {
+            DocumentHeaderContentTypePrefixes = null;
+
+            return this;
+        }
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicyHeader.cs
@@ -7,7 +7,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
     /// <summary>
     /// The header value to use for Content-Security-Policy
     /// </summary>
-    public abstract class ContentSecurityPolicyHeader : HtmlOnlyHeaderPolicyBase
+    public abstract class ContentSecurityPolicyHeader : DocumentHeaderPolicyBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ContentSecurityPolicyHeader"/> class.

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginOpenerPolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginOpenerPolicyHeader.cs
@@ -7,7 +7,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
     /// <summary>
     /// The header value to use for Cross-Origin-Opener-Policy
     /// </summary>
-    public abstract class CrossOriginOpenerPolicyHeader : HtmlOnlyHeaderPolicyBase
+    public abstract class CrossOriginOpenerPolicyHeader : DocumentHeaderPolicyBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CrossOriginOpenerPolicyHeader"/> class.

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/DocumentHeaderPolicyBase.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/DocumentHeaderPolicyBase.cs
@@ -1,0 +1,56 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers;
+
+/// <summary>
+/// A base implementation of <see cref="IHeaderPolicy" /> that only
+/// adds headers for specific content types.
+/// </summary>
+public abstract class DocumentHeaderPolicyBase : HeaderPolicyBase, IDocumentHeaderPolicy
+{
+    /// <inheritdoc />
+    public override void Apply(HttpContext context, CustomHeadersResult result)
+    {
+        // This method won't be called, as IDocumentHeaderPolicy is preferred
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public void Apply(HttpContext context, CustomHeadersResult result, HeaderPolicyCollection policies)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var request = context.Request;
+        var contentTypePrefixes = policies.DocumentHeaderContentTypePrefixes;
+        if (contentTypePrefixes is null || IsMatch(context, contentTypePrefixes))
+        {
+            if (request.IsHttps)
+            {
+                EvaluateHttpsRequest(context, result);
+            }
+            else
+            {
+                EvaluateHttpRequest(context, result);
+            }
+        }
+    }
+
+    private static bool IsMatch(HttpContext context, string[] contentTypes)
+    {
+        foreach (var contentTypePrefix in contentTypes)
+        {
+            if (context.Response.ContentType?.StartsWith(contentTypePrefix) ?? true)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/FeaturePolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/FeaturePolicyHeader.cs
@@ -7,7 +7,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
     /// <summary>
     /// The header value to use for Feature-Policy.
     /// </summary>
-    public class FeaturePolicyHeader : HtmlOnlyHeaderPolicyBase
+    public class FeaturePolicyHeader : DocumentHeaderPolicyBase
     {
         private readonly string _value;
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/HeaderPolicyBase.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/HeaderPolicyBase.cs
@@ -23,7 +23,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
         protected abstract string GetValue(HttpContext context);
 
         /// <inheritdoc />
-        public void Apply(HttpContext context, CustomHeadersResult result)
+        public virtual void Apply(HttpContext context, CustomHeadersResult result)
         {
             if (context == null)
             {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/IDocumentHeaderPolicy.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/IDocumentHeaderPolicy.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers;
+
+/// <summary>
+/// A header policy that represents a document-based header, which only needs
+/// to be applied to a sub set of requests
+/// </summary>
+internal interface IDocumentHeaderPolicy : IHeaderPolicy
+{
+    /// <summary>
+    /// Apply the header to the result given the provided context
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> associated with the current call.</param>
+    /// <param name="result">The <see cref="CustomHeadersResult"/> to update.</param>
+    /// <param name="policies">The <see cref="HeaderPolicyCollection"/> applied to the request</param>
+    void Apply(HttpContext context, CustomHeadersResult result, HeaderPolicyCollection policies);
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeader.cs
@@ -7,7 +7,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
     /// <summary>
     /// The header value to use for Permissions-Policy.
     /// </summary>
-    public class PermissionsPolicyHeader : HtmlOnlyHeaderPolicyBase
+    public class PermissionsPolicyHeader : DocumentHeaderPolicyBase
     {
         private readonly string _value;
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ReferrerPolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ReferrerPolicyHeader.cs
@@ -5,7 +5,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
     /// <summary>
     /// The header value to use for ReferrerPolicy
     /// </summary>
-    public class ReferrerPolicyHeader : HtmlOnlyHeaderPolicyBase
+    public class ReferrerPolicyHeader : DocumentHeaderPolicyBase
     {
         private readonly string _value;
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XFrameOptionsHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XFrameOptionsHeader.cs
@@ -5,7 +5,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
     /// <summary>
     /// The header value to use for X-Frame-Options
     /// </summary>
-    public class XFrameOptionsHeader : HtmlOnlyHeaderPolicyBase
+    public class XFrameOptionsHeader : DocumentHeaderPolicyBase
     {
         private readonly string _value;
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XssProtectionHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/XssProtectionHeader.cs
@@ -5,7 +5,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
     /// <summary>
     /// The header value to use for XSS-Protection
     /// </summary>
-    public class XssProtectionHeader : HtmlOnlyHeaderPolicyBase
+    public class XssProtectionHeader : DocumentHeaderPolicyBase
     {
         private readonly string _value;
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderService.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using NetEscapades.AspNetCore.SecurityHeaders.Headers;
 
 namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
 {
@@ -31,7 +32,14 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
             var result = new CustomHeadersResult();
             foreach (var policy in policies.Values)
             {
-                policy.Apply(context, result);
+                if (policy is IDocumentHeaderPolicy documentPolicy)
+                {
+                    documentPolicy.Apply(context, result, policies);
+                }
+                else
+                {
+                    policy.Apply(context, result);
+                }
             }
 
             return result;


### PR DESCRIPTION
Allow optionally applying all "document headers" (e.g. `Content-Security-Policy`, `Permissions-Policy`) that were previously only applied to responses with a `text/html` content-type, to more types of response. 

This PR adds 3 main things:

- An `internal` `IDocumentHeaderPolicy` interface
- A public `DocumentHeaderPolicyBase` abstract base class
- Two methods `ApplyDocumentHeadersToContentTypes()` and `ApplyDocumentHeadersToAllResponses()` on `HeaderPolicyCollection`

It also:

- Updates the existing headers that previously derived from `HtmlOnlyHeaderPolicyBase` to derive from `DocumentHeaderPolicyBase` instead
- Changes the default behaviour of document-based headers to apply to `text/html` _and_ `application/javascript` (so that it applies to web workers correctly). It's unlikely, but this **may** be a breaking change, if you're asserting on the expected headers in your responses, for example.

You can control what types of response the document headers are added to using `ApplyDocumentHeadersToContentTypes`. For example, the following changes the document headers to only be applied to JSON/ProblemDetails responses.

```csharp
app.UseSecurityHeaders(policies => policies
    .ApplyDocumentHeadersToContentTypes(new[] { "application/json", "application/problem"}) // 👈 Add this
    .AddContentSecurityPolicy(builder =>
    {
        builder.AddDefaultSrc().Self();
        builder.AddObjectSrc().None();
    }));
```

Alternatively, you can apply the headers to _all_ responses, using `ApplyDocumentHeadersToAllResponses()`

```csharp
app.UseSecurityHeaders(policies => policies
    .ApplyDocumentHeadersToAllResponses() // 👈 Add this
    .AddContentSecurityPolicy(builder =>
    {
        builder.AddDefaultSrc().Self();
        builder.AddObjectSrc().None();
    }));
```

Note that in both cases, this _only_ affects document-based headers like CSP. All other headers are always applied to all responses. The main limitation in this design is that you can't apply different document-headers to different content-types, e.g. CSP to HTML only, but permissions policy to JSON, but I think this is OK.

Fixes #119 