### PR TITLE
Corrected Copy/Paste errors in comments

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspBuilder.cs
@@ -82,14 +82,14 @@ public class CspBuilder
     public StyleSourceDirectiveBuilder AddStyleSrc() => AddDirective(new StyleSourceDirectiveBuilder());
 
     /// <summary>
-    /// The style-src-attr directive specifies valid sources for stylesheet &lt;style&gt; elements
-    /// and &lt;link&gt; elements with rel="stylesheet".
+    /// The style-src-attr directive specifies valid sources for inline styles applied to individual DOM elements.
     /// </summary>
     /// <returns>A configured <see cref="StyleSourceAttrDirectiveBuilder"/></returns>
     public StyleSourceAttrDirectiveBuilder AddStyleSrcAttr() => AddDirective(new StyleSourceAttrDirectiveBuilder());
 
     /// <summary>
-    /// The style-src-elem directive specifies valid sources for inline styles applied to individual DOM elements.
+    /// The style-src-elem directive specifies valid sources for stylesheet &lt;style&gt; elements
+    /// and &lt;link&gt; elements with rel="stylesheet".
     /// </summary>
     /// <returns>A configured <see cref="StyleSourceAttrDirectiveBuilder"/></returns>
     public StyleSourceElemDirectiveBuilder AddStyleSrcElem() => AddDirective(new StyleSourceElemDirectiveBuilder());

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceAttrDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceAttrDirectiveBuilder.cs
@@ -1,11 +1,10 @@
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The style-src-attr directive specifies valid sources for stylesheet &lt;style&gt; elements
-/// and &lt;link&gt; elements with rel="stylesheet".
+/// The style-src-attr directive specifies valid sources for inline styles applied to individual DOM elements.
 ///
-/// The directive does not set valid sources for inline style attributes; these are
-/// set using style-src-attr (and valid sources for all styles may be set with style-src).
+/// The directive does not set valid sources for &lt;style&gt; elements and &lt;link&gt; elements with rel="stylesheet".
+/// These are set using style-src-elem (and valid sources for all styles may be set with style-src).
 /// </summary>
 public class StyleSourceAttrDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceElemDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceElemDirectiveBuilder.cs
@@ -1,10 +1,11 @@
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The style-src-elem directive specifies valid sources for inline styles applied to individual DOM elements.
+/// The style-src-elem directive specifies valid sources for stylesheet &lt;style&gt; elements
+/// and &lt;link&gt; elements with rel="stylesheet".
 ///
-/// The directive does not set valid sources for &lt;style&gt; elements and &lt;link&gt; elements with rel="stylesheet".
-/// These are set using style-src-elem (and valid sources for all styles may be set with style-src).
+/// The directive does not set valid sources for inline style attributes; these are
+/// set using style-src-attr (and valid sources for all styles may be set with style-src).
 /// </summary>
 public class StyleSourceElemDirectiveBuilder : CspDirectiveBuilder
 {


### PR DESCRIPTION
I have corrected a few Copy/Paste errors in the documention of the StyleSourceAttr and StyleSourceElem directives.