### PR TITLE
Add support for `unsafe-hashes` on `style` attributes, and inline event handlers (fixes #155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,10 +481,16 @@ At runtime, these attributes are removed, but the hash values of the contents ar
 
 ### 5. Whitelist attributes using the TagHelpers
 
-Inline styles, and event handlers don't support nonces, but there is a dedicated tag helper that supports hashing attributes: `AttributeHashTagHelper`. This works the same as the tag helper for elements, but add the `asp-add-attribute-to-csp` attribute with the name of the attribute to hash, like this:
+Inline styles, and event handlers don't support nonces, but there is a dedicated tag helper that supports hashing attributes: `AttributeHashTagHelper`. This works similar as the tag helper for elements, but add the `asp-add-*-to-csp` attribute where `*` is the name of the attribute to hash, like this:
 
 ```html
-<h3 asp-add-attribute-to-csp="style" style="color: red">I will be styled red</h3>
+<h3 asp-add-style-to-csp style="color: red">I will be styled red</h3>
+```
+
+Multiple occurrences of this attribute is supported using different values for `*` in case you need to hash multiple attributes. You can still set the hash type by setting that on the attribute `asp-add-*-to-csp` directly (SHA256, SHA384, and SHA512 are still the valid options here):
+
+```html
+<button asp-add-style-to-csp style="color: red" asp-add-onclick-to-csp="SHA384" onclick="alert('Hello!')">Click me!</button>
 ```
 
 ### Using the generated nonce without a TagHelpers

--- a/README.md
+++ b/README.md
@@ -481,16 +481,16 @@ At runtime, these attributes are removed, but the hash values of the contents ar
 
 ### 5. Whitelist attributes using the TagHelpers
 
-Inline styles, and event handlers don't support nonces, but there is a dedicated tag helper that supports hashing attributes: `AttributeHashTagHelper`. This works similar to the tag helper for elements, but add the `asp-add-*-to-csp` attribute where `*` is the name of the attribute to hash, like this:
+Inline styles, and event handlers don't support nonces, but there is a dedicated tag helper that supports hashing attributes: `AttributeHashTagHelper`. This works similar to the tag helper for elements, but add the `asp-add-csp-for-*` attribute where `*` is the name of the attribute to hash, like this:
 
 ```html
-<h3 asp-add-style-to-csp style="color: red">I will be styled red</h3>
+<h3 asp-add-csp-for-style style="color: red">I will be styled red</h3>
 ```
 
-Multiple occurrences of this attribute is supported using different values for `*` in case you need to hash multiple attributes. You can still set the hash type by setting that on the attribute `asp-add-*-to-csp` directly (SHA256, SHA384, and SHA512 are still the valid options here):
+Multiple occurrences of this attribute is supported using different values for `*` in case you need to hash multiple attributes. You can still set the hash type by setting that on the attribute `asp-add-csp-for-*` directly (SHA256, SHA384, and SHA512 are still the valid options here):
 
 ```html
-<button asp-add-style-to-csp style="color: red" asp-add-onclick-to-csp="SHA384" onclick="alert('Hello!')">Click me!</button>
+<button asp-add-csp-for-style style="color: red" asp-add-csp-for-onclick="SHA384" onclick="alert('Hello!')">Click me!</button>
 ```
 
 ### Using the generated nonce without a TagHelpers

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ public void Configure(IApplicationBuilder app)
 
 The use of a secure Content-Security-Policy can sometimes be problematic when you need to include inline-scripts, styles, or other objects that haven't been whitelisted. You can achieve this in two ways - using a "nonce" (or "number-used-once"), or specifying the hash of the content to include. 
 
-To help with this you can install the NetEscapades.AspNetCore.SecurityHeaders.TagHelpers package, which provides helpers for generating a nonce per request, which is attached to the HTML element, and included in the CSP header. A similar method helper exists for `<style>` and `<script>` tags, which will take a SHA256 hash of the contents of the HTML element and add it to the CSP whitelist.
+To help with this you can install the NetEscapades.AspNetCore.SecurityHeaders.TagHelpers package, which provides helpers for generating a nonce per request, which is attached to the HTML element, and included in the CSP header. A similar method helper exists for `<style>` and `<script>` tags, which will take a SHA256 hash of the contents of the HTML element and add it to the CSP whitelist. For _inline styles_, and inline event handlers, there is an helper that supports generating hashes for the contents of such attribute.
 
 To use a nonce or an auto-generated hash with your ASP.NET Core application, use the following steps.
 
@@ -412,7 +412,7 @@ public void Configure(IApplicationBuilder app)
             builder.AddStyleSrc() // style-src 'self' 'strict-dynamic' 'sha256-<base64-value>'
                 .Self()
                 .StrictDynamic()
-                .WithHashTagHelper(); // Allow whitelsited elements based on their SHA256 hash value
+                .WithHashTagHelper().UnsafeHashes(); // Allow whitelsited elements based on their SHA256 hash value
         })
         .AddCustomHeader("X-My-Test-Header", "Header value");
 
@@ -430,7 +430,7 @@ Add the following to the *_ViewImports.cshtml* file in your application. This ma
 @addTagHelper *, NetEscapades.AspNetCore.SecurityHeaders.TagHelpers
 ```
 
-### 4. Whitelist elements using the TagHelpers
+### 4. Whitelist elements, and attributes using the TagHelpers
 
 Add the `NonceTagHelper` to an element by adding the `asp-add-nonce` attribute.
 
@@ -478,6 +478,14 @@ To use a whitelisted hash instead, use the `HashTagHelper`, by adding the `asp-a
 ```
 
 At runtime, these attributes are removed, but the hash values of the contents are added to the `Content-Security-Policy header`.
+
+### 5. Whitelist attributes using the TagHelpers
+
+Inline styles, and event handlers don't support nonces, but there is a dedicated tag helper that supports hashing attributes: `AttributeHashTagHelper`. This works the same as the tag helper for elements, but add the `asp-add-attribute-to-csp` attribute with the name of the attribute to hash, like this:
+
+```html
+<h3 asp-add-attribute-to-csp="style" style="color: red">I will be styled red</h3>
+```
 
 ### Using the generated nonce without a TagHelpers
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ public void Configure(IApplicationBuilder app)
             builder.AddStyleSrc() // style-src 'self' 'strict-dynamic' 'sha256-<base64-value>'
                 .Self()
                 .StrictDynamic()
-                .WithHashTagHelper().UnsafeHashes(); // Allow whitelsited elements based on their SHA256 hash value
+                .WithHashTagHelper().UnsafeHashes(); // Allow allowlisted elements based on their SHA256 hash value
         })
         .AddCustomHeader("X-My-Test-Header", "Header value");
 
@@ -492,6 +492,8 @@ Multiple occurrences of this attribute is supported using different values for `
 ```html
 <button asp-add-csp-for-style style="color: red" asp-add-csp-for-onclick="SHA384" onclick="alert('Hello!')">Click me!</button>
 ```
+
+At runtime, these attributes are removed, but the hash values of the contents are added to the `Content-Security-Policy header`.
 
 ### Using the generated nonce without a TagHelpers
 

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Add the following to the *_ViewImports.cshtml* file in your application. This ma
 @addTagHelper *, NetEscapades.AspNetCore.SecurityHeaders.TagHelpers
 ```
 
-### 4. Whitelist elements, and attributes using the TagHelpers
+### 4. Whitelist elements using the TagHelpers
 
 Add the `NonceTagHelper` to an element by adding the `asp-add-nonce` attribute.
 
@@ -481,7 +481,7 @@ At runtime, these attributes are removed, but the hash values of the contents ar
 
 ### 5. Whitelist attributes using the TagHelpers
 
-Inline styles, and event handlers don't support nonces, but there is a dedicated tag helper that supports hashing attributes: `AttributeHashTagHelper`. This works similar as the tag helper for elements, but add the `asp-add-*-to-csp` attribute where `*` is the name of the attribute to hash, like this:
+Inline styles, and event handlers don't support nonces, but there is a dedicated tag helper that supports hashing attributes: `AttributeHashTagHelper`. This works similar to the tag helper for elements, but add the `asp-add-*-to-csp` attribute where `*` is the name of the attribute to hash, like this:
 
 ```html
 <h3 asp-add-style-to-csp style="color: red">I will be styled red</h3>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers;
+
+/// <summary>
+/// Generates an hash of style, or inline script attributes
+/// </summary>
+public class AttributeHashTagHelper : TagHelper
+{
+    private const string CspHashTypeAttributeName = "csp-hash-type";
+
+    /// <summary>
+    /// Add a <code>csp-hash-type</code> attribute to the element
+    /// </summary>
+    [HtmlAttributeName(CspHashTypeAttributeName)]
+    public CSPHashType CSPHashType { get; set; } = CSPHashType.SHA256;
+
+    /// <summary>
+    /// Provides access to the <see cref="ViewContext"/>
+    /// </summary>
+    [ViewContext]
+    public ViewContext? ViewContext { get; set; }
+
+    /// <inheritdoc />
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        base.Process(context, output);
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -50,7 +50,10 @@ public class AttributeHashTagHelper : TagHelper
         // properly handle null results from ToString()
         var content = targetAttributeValue.Value.ToString();
 
-        var contentBytes = Encoding.UTF8.GetBytes(content!);
+        // the hash is calculated based on unix line endings, not windows endings, so account for that
+        var unixContent = content!.Replace("\r\n", "\n");
+
+        var contentBytes = Encoding.UTF8.GetBytes(unixContent);
         var hashedBytes = sha.ComputeHash(contentBytes);
         var hash = Convert.ToBase64String(hashedBytes);
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -34,6 +35,20 @@ public class AttributeHashTagHelper : TagHelper
         {
             throw new InvalidOperationException("ViewContext was null");
         }
+
+        using var sha = CryptographyAlgorithms.Create(CSPHashType);
+
+        var styleAttributeValue = context.AllAttributes["style"];
+
+        // TODO: properly handle Value as object (just ToString?)
+        // properly handle null results from ToString()
+        var content = styleAttributeValue.Value.ToString();
+
+        var contentBytes = Encoding.UTF8.GetBytes(content!);
+        var hashedBytes = sha.ComputeHash(contentBytes);
+        var hash = Convert.ToBase64String(hashedBytes);
+
+        ViewContext.HttpContext.SetStylesCSPHash(CSPHashType, hash);
 
         output.Attributes.RemoveAll(AttributeName);
         output.Attributes.RemoveAll(CspHashTypeAttributeName);

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -44,17 +44,24 @@ public class AttributeHashTagHelper : TagHelper
 
         using var sha = CryptographyAlgorithms.Create(CSPHashType);
 
-        var styleAttributeValue = context.AllAttributes["style"];
+        var targetAttributeValue = context.AllAttributes[TargetAttributeName];
 
         // TODO: properly handle Value as object (just ToString?)
         // properly handle null results from ToString()
-        var content = styleAttributeValue.Value.ToString();
+        var content = targetAttributeValue.Value.ToString();
 
         var contentBytes = Encoding.UTF8.GetBytes(content!);
         var hashedBytes = sha.ComputeHash(contentBytes);
         var hash = Convert.ToBase64String(hashedBytes);
 
-        ViewContext.HttpContext.SetStylesCSPHash(CSPHashType, hash);
+        if (TargetAttributeName == "style")
+        {
+            ViewContext.HttpContext.SetStylesCSPHash(CSPHashType, hash);
+        }
+        else
+        {
+            ViewContext.HttpContext.SetScriptCSPHash(CSPHashType, hash);
+        }
 
         output.Attributes.RemoveAll(AttributeName);
         output.Attributes.RemoveAll(CspHashTypeAttributeName);

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -13,8 +13,14 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers;
 [HtmlTargetElement("*", Attributes = AttributeName)]
 public class AttributeHashTagHelper : TagHelper
 {
-    private const string AttributeName = "asp-add-style-attribute-to-csp";
+    private const string AttributeName = "asp-add-attribute-to-csp";
     private const string CspHashTypeAttributeName = "csp-hash-type";
+
+    /// <summary>
+    /// Add a <code>asp-add-attribute-to-csp</code> attribute to the element
+    /// </summary>
+    [HtmlAttributeName(AttributeName)]
+    public string TargetAttributeName { get; set; } = default!;
 
     /// <summary>
     /// Add a <code>csp-hash-type</code> attribute to the element

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -10,7 +10,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers;
 /// <summary>
 /// Generates an hash of style, or inline script attributes
 /// </summary>
-[HtmlTargetElement("style", Attributes = AttributeName)]
+[HtmlTargetElement("*", Attributes = AttributeName)]
 public class AttributeHashTagHelper : TagHelper
 {
     private const string AttributeName = "asp-add-style-attribute-to-csp";

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -35,7 +35,10 @@ public class AttributeHashTagHelper : TagHelper
 
         var cspAttributes = context
             .AllAttributes
-            .Where(a => a.Name.StartsWith(AttributePrefix) && a.Name.EndsWith(AttributeSuffix) && a.Name != "asp-add-content-to-csp")
+            .Where(a =>
+                a.Name.StartsWith(AttributePrefix)
+                && a.Name.EndsWith(AttributeSuffix)
+                && a.Name != HashTagHelper.AttributeName)
             .ToList();
 
         foreach (var cspAttribute in cspAttributes)

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -38,8 +38,7 @@ public class AttributeHashTagHelper : TagHelper
             .Where(a =>
                 a.Name.StartsWith(AttributePrefix)
                 && a.Name.EndsWith(AttributeSuffix)
-                && a.Name != HashTagHelper.AttributeName)
-            .ToList();
+                && a.Name != HashTagHelper.AttributeName);
 
         foreach (var cspAttribute in cspAttributes)
         {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -14,8 +14,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers;
 [HtmlTargetElement("*", Attributes = AttributePrefix + "*")]
 public class AttributeHashTagHelper : TagHelper
 {
-    private const string AttributePrefix = "asp-add-";
-    private const string AttributeSuffix = "-to-csp";
+    private const string AttributePrefix = "asp-add-csp-for-";
 
     private const CSPHashType DefaultHashType = CSPHashType.SHA256;
 
@@ -36,9 +35,7 @@ public class AttributeHashTagHelper : TagHelper
         var cspAttributes = context
             .AllAttributes
             .Where(a =>
-                a.Name.StartsWith(AttributePrefix)
-                && a.Name.EndsWith(AttributeSuffix)
-                && a.Name != "asp-add-content-to-csp");
+                a.Name.StartsWith(AttributePrefix));
 
         foreach (var cspAttribute in cspAttributes)
         {
@@ -84,9 +81,7 @@ public class AttributeHashTagHelper : TagHelper
     }
 
     private string ParseTargetAttributeName(string cspAttributeName)
-        => cspAttributeName
-            .Replace(AttributePrefix, string.Empty)
-            .Replace(AttributeSuffix, string.Empty);
+        => cspAttributeName.Replace(AttributePrefix, string.Empty);
 
     private CSPHashType ParseHashType(string? hashTypeText)
         => Enum.TryParse<CSPHashType>(hashTypeText, out var hashType)

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -32,14 +32,12 @@ public class AttributeHashTagHelper : TagHelper
             throw new InvalidOperationException("ViewContext was null");
         }
 
-        var cspAttributes = context
-            .AllAttributes
-            .Where(a =>
-                a.Name.StartsWith(AttributePrefix));
-
-        foreach (var cspAttribute in cspAttributes)
+        foreach (var cspAttribute in context.AllAttributes)
         {
-            ProcessAttribute(ViewContext, context, output, cspAttribute);
+            if (cspAttribute.Name.StartsWith(AttributePrefix))
+            {
+                ProcessAttribute(ViewContext, context, output, cspAttribute);
+            }
         }
     }
 
@@ -81,7 +79,7 @@ public class AttributeHashTagHelper : TagHelper
     }
 
     private string ParseTargetAttributeName(string cspAttributeName)
-        => cspAttributeName.Replace(AttributePrefix, string.Empty);
+        => cspAttributeName.Substring(AttributePrefix.Length);
 
     private CSPHashType ParseHashType(string? hashTypeText)
         => Enum.TryParse<CSPHashType>(hashTypeText, out var hashType)

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.Rendering;
+﻿using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-
 using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
 
 namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers;
@@ -9,8 +9,10 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers;
 /// <summary>
 /// Generates an hash of style, or inline script attributes
 /// </summary>
+[HtmlTargetElement("style", Attributes = AttributeName)]
 public class AttributeHashTagHelper : TagHelper
 {
+    private const string AttributeName = "asp-add-style-attribute-to-csp";
     private const string CspHashTypeAttributeName = "csp-hash-type";
 
     /// <summary>
@@ -28,6 +30,12 @@ public class AttributeHashTagHelper : TagHelper
     /// <inheritdoc />
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
-        base.Process(context, output);
+        if (ViewContext is null)
+        {
+            throw new InvalidOperationException("ViewContext was null");
+        }
+
+        output.Attributes.RemoveAll(AttributeName);
+        output.Attributes.RemoveAll(CspHashTypeAttributeName);
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -57,11 +57,10 @@ public class AttributeHashTagHelper : TagHelper
             ? ParseHashType(cspAttribute.Value.ToString())
             : DefaultHashType;
 
-        var sha = CryptographyAlgorithms.Create(cspHashType);
-
         var targetAttributeValue = context.AllAttributes[targetAttributeName];
         if (targetAttributeValue is not null)
         {
+            using var sha = CryptographyAlgorithms.Create(cspHashType);
             var content = targetAttributeValue.Value.ToString();
 
             // the hash is calculated based on unix line endings, not windows endings, so account for that

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -45,25 +45,25 @@ public class AttributeHashTagHelper : TagHelper
         using var sha = CryptographyAlgorithms.Create(CSPHashType);
 
         var targetAttributeValue = context.AllAttributes[TargetAttributeName];
-
-        // TODO: properly handle Value as object (just ToString?)
-        // properly handle null results from ToString()
-        var content = targetAttributeValue.Value.ToString();
-
-        // the hash is calculated based on unix line endings, not windows endings, so account for that
-        var unixContent = content!.Replace("\r\n", "\n");
-
-        var contentBytes = Encoding.UTF8.GetBytes(unixContent);
-        var hashedBytes = sha.ComputeHash(contentBytes);
-        var hash = Convert.ToBase64String(hashedBytes);
-
-        if (TargetAttributeName == "style")
+        if (targetAttributeValue is not null)
         {
-            ViewContext.HttpContext.SetStylesCSPHash(CSPHashType, hash);
-        }
-        else
-        {
-            ViewContext.HttpContext.SetScriptCSPHash(CSPHashType, hash);
+            var content = targetAttributeValue.Value.ToString();
+
+            // the hash is calculated based on unix line endings, not windows endings, so account for that
+            var unixContent = content!.Replace("\r\n", "\n");
+
+            var contentBytes = Encoding.UTF8.GetBytes(unixContent);
+            var hashedBytes = sha.ComputeHash(contentBytes);
+            var hash = Convert.ToBase64String(hashedBytes);
+
+            if (TargetAttributeName == "style")
+            {
+                ViewContext.HttpContext.SetStylesCSPHash(CSPHashType, hash);
+            }
+            else
+            {
+                ViewContext.HttpContext.SetScriptCSPHash(CSPHashType, hash);
+            }
         }
 
         output.Attributes.RemoveAll(AttributeName);

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/AttributeHashTagHelper.cs
@@ -38,7 +38,7 @@ public class AttributeHashTagHelper : TagHelper
             .Where(a =>
                 a.Name.StartsWith(AttributePrefix)
                 && a.Name.EndsWith(AttributeSuffix)
-                && a.Name != HashTagHelper.AttributeName);
+                && a.Name != "asp-add-content-to-csp");
 
         foreach (var cspAttribute in cspAttributes)
         {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/HashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/HashTagHelper.cs
@@ -19,7 +19,7 @@ public class HashTagHelper : TagHelper
     private const string CspHashTypeAttributeName = "csp-hash-type";
 
     /// <summary>
-    /// Add a <code>nonce</code> attribute to the element
+    /// Add a <code>csp-hash-type</code> attribute to the element
     /// </summary>
     [HtmlAttributeName(CspHashTypeAttributeName)]
     public CSPHashType CSPHashType { get; set; } = CSPHashType.SHA256;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/HashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/HashTagHelper.cs
@@ -15,7 +15,11 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers;
 [HtmlTargetElement("style", Attributes = AttributeName)]
 public class HashTagHelper : TagHelper
 {
-    private const string AttributeName = "asp-add-content-to-csp";
+    /// <summary>
+    /// Target attribute for this tag helper
+    /// </summary>
+    internal const string AttributeName = "asp-add-content-to-csp";
+
     private const string CspHashTypeAttributeName = "csp-hash-type";
 
     /// <summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/HashTagHelper.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/HashTagHelper.cs
@@ -15,11 +15,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers;
 [HtmlTargetElement("style", Attributes = AttributeName)]
 public class HashTagHelper : TagHelper
 {
-    /// <summary>
-    /// Target attribute for this tag helper
-    /// </summary>
-    internal const string AttributeName = "asp-add-content-to-csp";
-
+    private const string AttributeName = "asp-add-content-to-csp";
     private const string CspHashTypeAttributeName = "csp-hash-type";
 
     /// <summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceAttrDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceAttrDirectiveBuilder.cs
@@ -30,7 +30,7 @@ public class ScriptSourceAttrDirectiveBuilder : CspDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow sources for content generated using the the HashTagHelper.
+    /// Allow sources for content generated using the HashTagHelper.
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ScriptSourceAttrDirectiveBuilder WithHashTagHelper()

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceDirectiveBuilder.cs
@@ -26,7 +26,7 @@ public class ScriptSourceDirectiveBuilder : CspDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow sources for content generated using the the HashTagHelper.
+    /// Allow sources for content generated using the HashTagHelper.
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ScriptSourceDirectiveBuilder WithHashTagHelper()

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceElemDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceElemDirectiveBuilder.cs
@@ -30,7 +30,7 @@ public class ScriptSourceElemDirectiveBuilder : CspDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow sources for content generated using the the HashTagHelper.
+    /// Allow sources for content generated using the HashTagHelper.
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ScriptSourceElemDirectiveBuilder WithHashTagHelper()

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceAttrDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceAttrDirectiveBuilder.cs
@@ -27,7 +27,7 @@ public class StyleSourceAttrDirectiveBuilder : CspDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow sources for content generated using the the HashTagHelper.
+    /// Allow sources for content generated using the HashTagHelper.
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public StyleSourceAttrDirectiveBuilder WithHashTagHelper()

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
@@ -24,7 +24,7 @@ public class StyleSourceDirectiveBuilder : CspDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow sources for content generated using the the HashTagHelper.
+    /// Allow sources for content generated using the HashTagHelper.
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public StyleSourceDirectiveBuilder WithHashTagHelper()

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceElemDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceElemDirectiveBuilder.cs
@@ -28,7 +28,7 @@ public class StyleSourceElemDirectiveBuilder : CspDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow sources for content generated using the the HashTagHelper.
+    /// Allow sources for content generated using the HashTagHelper.
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public StyleSourceElemDirectiveBuilder WithHashTagHelper()

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/CrossOriginPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/CrossOriginPolicies/CrossOriginPolicyBuilder.cs
@@ -27,7 +27,7 @@ public abstract class CrossOriginPolicyBuilder
     /// Adds a directive for the cross origin policy
     /// </summary>
     /// <typeparam name="T">The type of the directive</typeparam>
-    /// <param name="directive">The directive corresponding the the concrete implementation of the cross origin policy.</param>
+    /// <param name="directive">The directive corresponding the concrete implementation of the cross origin policy.</param>
     /// <returns>A configured <see cref="CrossOriginPolicyDirectiveBuilderBase"/> implementation.</returns>
     protected T AddDirective<T>(T directive) where T : CrossOriginPolicyDirectiveBuilderBase
     {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HttpContextExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HttpContextExtensions.cs
@@ -40,7 +40,7 @@ public static class HttpContextExtensions
     /// Adds a CSP hash to the collection of sources for script-src
     /// </summary>
     /// <param name="context">The <see cref="HttpContext"/> for the request</param>
-    /// <param name="algorithm">The algorithm used to calcualte the hash</param>
+    /// <param name="algorithm">The algorithm used to calculate the hash</param>
     /// <param name="hash">The hash generated from the content</param>
     public static void SetScriptCSPHash(this HttpContext context, CSPHashType algorithm, string hash)
     {
@@ -51,7 +51,7 @@ public static class HttpContextExtensions
     /// Adds a CSP hash to the collection of sources for style-src
     /// </summary>
     /// <param name="context">The <see cref="HttpContext"/> for the request</param>
-    /// <param name="algorithm">The algorithm used to calcualte the hash</param>
+    /// <param name="algorithm">The algorithm used to calculate the hash</param>
     /// <param name="hash">The hash generated from the content</param>
     public static void SetStylesCSPHash(this HttpContext context, CSPHashType algorithm, string hash)
     {

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
@@ -28,7 +28,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-style-attribute-to-csp");
+            var cspAttribute = new TagHelperAttribute("asp-add-attribute-to-csp", "style");
             var fixture = CreateFixture(id, tagName, new([styleAttribute, cspAttribute]));
             var tagHelper = new AttributeHashTagHelper()
             {
@@ -52,7 +52,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-style-attribute-to-csp");
+            var cspAttribute = new TagHelperAttribute("asp-add-attribute-to-csp", "style");
             var fixture = CreateFixture(id, tagName, new([styleAttribute, cspAttribute]));
             var tagHelper = new AttributeHashTagHelper()
             {

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -7,16 +11,8 @@ using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.AspNetCore.Routing;
-
 using Moq;
-
 using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
-
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-
 using Xunit;
 
 namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test
@@ -57,7 +53,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test
 
             // Assert
             Assert.Equal(tagName, output.TagName);
-            Assert.Empty(output.Attributes);
+            Assert.Equal([styleAttribute], output.Attributes);
             Assert.Empty(output.Content.GetContent());
         }
 

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
@@ -20,6 +20,11 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test
     public class AttributeHashTagHelperTests
     {
         const string inlineStyleSnippet = "color: red";
+        const string inlineMultiLineStyleSnippet = @"
+color: red;
+background: blue;
+";
+
         const string inlineScriptSnippet = "myScript()";
 
         [Fact]
@@ -69,6 +74,31 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test
             // Assert
             var hash = Assert.Single(tagHelper.ViewContext.HttpContext.GetStyleCSPHashes());
             var expected = "'sha256-NerDAUWfwD31YdZHveMrq0GLjsNFMwxLpZl0dPUeCcw='";
+            Assert.Equal(expected, hash);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_StyleAttributeWithMultiLine_AddsHashToHttpContext()
+        {
+            // Arrange
+            var id = Guid.NewGuid().ToString();
+            var tagName = "div";
+            var styleAttribute = new TagHelperAttribute("style", inlineMultiLineStyleSnippet);
+            var cspAttribute = new TagHelperAttribute("asp-add-attribute-to-csp", "style");
+            var fixture = CreateFixture(id, tagName, new([styleAttribute, cspAttribute]));
+            var tagHelper = new AttributeHashTagHelper()
+            {
+                TargetAttributeName = "style",
+                CSPHashType = CSPHashType.SHA256,
+                ViewContext = GetViewContext(),
+            };
+
+            // Act
+            await tagHelper.ProcessAsync(fixture.Context, fixture.Output);
+
+            // Assert
+            var hash = Assert.Single(tagHelper.ViewContext.HttpContext.GetStyleCSPHashes());
+            var expected = "'sha256-ly/Q8sGjROqYelSQCwIsD00L09JdMcVcMFTDyK7N7GM='";
             Assert.Equal(expected, hash);
         }
 

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
@@ -34,7 +34,7 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
+            var cspAttribute = new TagHelperAttribute("asp-add-csp-for-style");
             var fixture = CreateFixture(id, tagName, styleAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
@@ -57,7 +57,7 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
+            var cspAttribute = new TagHelperAttribute("asp-add-csp-for-style");
             var fixture = CreateFixture(id, tagName, styleAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
@@ -80,7 +80,7 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp", "SHA384");
+            var cspAttribute = new TagHelperAttribute("asp-add-csp-for-style", "SHA384");
             var fixture = CreateFixture(id, tagName, styleAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
@@ -103,7 +103,7 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineMultiLineStyleSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
+            var cspAttribute = new TagHelperAttribute("asp-add-csp-for-style");
             var fixture = CreateFixture(id, tagName, styleAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
@@ -125,7 +125,7 @@ background: blue;
             // Arrange
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
-            var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
+            var cspAttribute = new TagHelperAttribute("asp-add-csp-for-style");
             var fixture = CreateFixture(id, tagName, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
@@ -148,7 +148,7 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var inlineScriptAttribute = new TagHelperAttribute("onclick", inlineScriptSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-onclick-to-csp");
+            var cspAttribute = new TagHelperAttribute("asp-add-csp-for-onclick");
             var fixture = CreateFixture(id, tagName, inlineScriptAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
@@ -171,7 +171,7 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var inlineScriptAttribute = new TagHelperAttribute("onclick", inlineScriptSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-onclick-to-csp");
+            var cspAttribute = new TagHelperAttribute("asp-add-csp-for-onclick");
             var fixture = CreateFixture(id, tagName, inlineScriptAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
@@ -196,8 +196,8 @@ background: blue;
 
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
             var inlineScriptAttribute = new TagHelperAttribute("onclick", inlineScriptSnippet);
-            var cspStyleAttribute = new TagHelperAttribute("asp-add-style-to-csp");
-            var cspScriptAttribute = new TagHelperAttribute("asp-add-onclick-to-csp");
+            var cspStyleAttribute = new TagHelperAttribute("asp-add-csp-for-style");
+            var cspScriptAttribute = new TagHelperAttribute("asp-add-csp-for-onclick");
 
             var fixture = CreateFixture(id, tagName,
                 styleAttribute,

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
+
+using Moq;
+
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test
+{
+    public class AttributeHashTagHelperTests
+    {
+        const string inlineStyleSnippet = "color: red";
+
+        [Fact]
+        public async Task ProcessAsync_StyleAttribute_GeneratesExpectedOutput()
+        {
+            // Arrange
+            var id = Guid.NewGuid().ToString();
+            var tagName = "div";
+            var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
+            var cspAttribute = new TagHelperAttribute("asp-add-style-attribute-to-csp");
+            var tagHelperContext = GetTagHelperContext(id, tagName, new([styleAttribute, cspAttribute]));
+            var tagHelper = new HashTagHelper()
+            {
+                CSPHashType = CSPHashType.SHA256,
+                ViewContext = GetViewContext(),
+            };
+
+            var output = new TagHelperOutput(
+               tagName,
+               attributes: new([styleAttribute, cspAttribute]),
+               getChildContentAsync: (useCachedResult, encoder) =>
+               {
+                   var tagHelperContent = new DefaultTagHelperContent();
+                   //tagHelperContent.SetHtmlContent(scriptSnippet);
+                   return Task.FromResult<TagHelperContent>(tagHelperContent);
+               });
+
+            //output.Content.SetHtmlContent(styleSnippet);
+
+            // Act
+            await tagHelper.ProcessAsync(tagHelperContext, output);
+
+            // Assert
+            Assert.Equal(tagName, output.TagName);
+            Assert.Empty(output.Attributes);
+            Assert.Empty(output.Content.GetContent());
+        }
+
+        [Fact]
+        public async Task ProcessAsync_StyleAttribute_AddsHashToHttpContext()
+        {
+            // Arrange
+            var id = Guid.NewGuid().ToString();
+            var tagName = "style";
+            var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
+            var cspAttribute = new TagHelperAttribute("asp-add-style-attribute-to-csp");
+            var tagHelperContext = GetTagHelperContext(id, tagName, new([styleAttribute, cspAttribute]));
+            var tagHelper = new HashTagHelper()
+            {
+                CSPHashType = CSPHashType.SHA256,
+                ViewContext = GetViewContext(),
+            };
+
+            var output = new TagHelperOutput(
+               tagName,
+               attributes: new([styleAttribute, cspAttribute]),
+               getChildContentAsync: (useCachedResult, encoder) =>
+               {
+                   var tagHelperContent = new DefaultTagHelperContent();
+                   //tagHelperContent.SetHtmlContent(styleSnippet);
+                   return Task.FromResult<TagHelperContent>(tagHelperContent);
+               });
+
+            // Act
+            await tagHelper.ProcessAsync(tagHelperContext, output);
+
+            // Assert
+            var hash = Assert.Single(tagHelper.ViewContext.HttpContext.GetStyleCSPHashes());
+            var expected = "'sha256-Wz9o8J/ijdXtAzs95rmQ8OtBacYk6JfYTXQlM8yxIjg='";
+            Assert.Equal(expected, hash);
+        }
+
+        private static ViewContext GetViewContext()
+        {
+            var actionContext = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
+            return new ViewContext(actionContext,
+                                   Mock.Of<IView>(),
+                                   new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary()),
+                                   Mock.Of<ITempDataDictionary>(),
+                                   TextWriter.Null,
+                                   new HtmlHelperOptions());
+        }
+
+        private static TagHelperContext GetTagHelperContext(string id, string tagName, TagHelperAttributeList attributes)
+        {
+            return new TagHelperContext(
+                tagName: tagName,
+                allAttributes: attributes,
+                items: new Dictionary<object, object>(),
+                uniqueId: id);
+        }
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
@@ -34,7 +34,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
             var cspAttribute = new TagHelperAttribute("asp-add-style-attribute-to-csp");
             var tagHelperContext = GetTagHelperContext(id, tagName, new([styleAttribute, cspAttribute]));
-            var tagHelper = new HashTagHelper()
+            var tagHelper = new AttributeHashTagHelper()
             {
                 CSPHashType = CSPHashType.SHA256,
                 ViewContext = GetViewContext(),
@@ -70,7 +70,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
             var cspAttribute = new TagHelperAttribute("asp-add-style-attribute-to-csp");
             var tagHelperContext = GetTagHelperContext(id, tagName, new([styleAttribute, cspAttribute]));
-            var tagHelper = new HashTagHelper()
+            var tagHelper = new AttributeHashTagHelper()
             {
                 CSPHashType = CSPHashType.SHA256,
                 ViewContext = GetViewContext(),

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
@@ -103,6 +103,30 @@ background: blue;
         }
 
         [Fact]
+        public async Task ProcessAsync_StyleAttributeTargetingNonExistingAttribute_DoesntAddAndCleansUp()
+        {
+            // Arrange
+            var id = Guid.NewGuid().ToString();
+            var tagName = "div";
+            var cspAttribute = new TagHelperAttribute("asp-add-attribute-to-csp", "style");
+            var fixture = CreateFixture(id, tagName, new([cspAttribute]));
+            var tagHelper = new AttributeHashTagHelper()
+            {
+                TargetAttributeName = "style",
+                CSPHashType = CSPHashType.SHA256,
+                ViewContext = GetViewContext(),
+            };
+
+            // Act
+            await tagHelper.ProcessAsync(fixture.Context, fixture.Output);
+
+            // Assert
+            Assert.Equal(tagName, fixture.Output.TagName);
+            Assert.Empty(fixture.Output.Attributes);
+            Assert.Empty(fixture.Output.Content.GetContent());
+        }
+
+        [Fact]
         public async Task ProcessAsync_InlineScriptAttribute_GeneratesExpectedOutput()
         {
             // Arrange

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
@@ -35,7 +35,7 @@ background: blue;
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
             var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
-            var fixture = CreateFixture(id, tagName, new([styleAttribute, cspAttribute]));
+            var fixture = CreateFixture(id, tagName, styleAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
                 ViewContext = GetViewContext(),
@@ -58,7 +58,7 @@ background: blue;
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
             var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
-            var fixture = CreateFixture(id, tagName, new([styleAttribute, cspAttribute]));
+            var fixture = CreateFixture(id, tagName, styleAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
                 ViewContext = GetViewContext(),
@@ -81,7 +81,7 @@ background: blue;
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
             var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp", "SHA384");
-            var fixture = CreateFixture(id, tagName, new([styleAttribute, cspAttribute]));
+            var fixture = CreateFixture(id, tagName, styleAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
                 ViewContext = GetViewContext(),
@@ -104,7 +104,7 @@ background: blue;
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineMultiLineStyleSnippet);
             var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
-            var fixture = CreateFixture(id, tagName, new([styleAttribute, cspAttribute]));
+            var fixture = CreateFixture(id, tagName, styleAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
                 ViewContext = GetViewContext(),
@@ -126,7 +126,7 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
-            var fixture = CreateFixture(id, tagName, new([cspAttribute]));
+            var fixture = CreateFixture(id, tagName, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
                 ViewContext = GetViewContext(),
@@ -149,7 +149,7 @@ background: blue;
             var tagName = "div";
             var inlineScriptAttribute = new TagHelperAttribute("onclick", inlineScriptSnippet);
             var cspAttribute = new TagHelperAttribute("asp-add-onclick-to-csp");
-            var fixture = CreateFixture(id, tagName, new([inlineScriptAttribute, cspAttribute]));
+            var fixture = CreateFixture(id, tagName, inlineScriptAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
                 ViewContext = GetViewContext(),
@@ -172,7 +172,7 @@ background: blue;
             var tagName = "div";
             var inlineScriptAttribute = new TagHelperAttribute("onclick", inlineScriptSnippet);
             var cspAttribute = new TagHelperAttribute("asp-add-onclick-to-csp");
-            var fixture = CreateFixture(id, tagName, new([inlineScriptAttribute, cspAttribute]));
+            var fixture = CreateFixture(id, tagName, inlineScriptAttribute, cspAttribute);
             var tagHelper = new AttributeHashTagHelper()
             {
                 ViewContext = GetViewContext(),
@@ -199,13 +199,12 @@ background: blue;
             var cspStyleAttribute = new TagHelperAttribute("asp-add-style-to-csp");
             var cspScriptAttribute = new TagHelperAttribute("asp-add-onclick-to-csp");
 
-            var fixture = CreateFixture(id, tagName, new(
-            [
+            var fixture = CreateFixture(id, tagName,
                 styleAttribute,
                 inlineScriptAttribute,
                 cspStyleAttribute,
                 cspScriptAttribute
-            ]));
+            );
 
             var tagHelper = new AttributeHashTagHelper()
             {
@@ -225,12 +224,12 @@ background: blue;
             Assert.Equal(expectedScriptHash, scriptHash);
         }
 
-        private static Fixture CreateFixture(string id, string tagName, TagHelperAttributeList attributes)
+        private static Fixture CreateFixture(string id, string tagName, params TagHelperAttribute[] attributes)
         {
             return new Fixture
             {
-                Context = GetTagHelperContext(id, tagName, attributes),
-                Output = GetTagHelperOutput(id, tagName, attributes)
+                Context = GetTagHelperContext(id, tagName, new(attributes)),
+                Output = GetTagHelperOutput(id, tagName, new(attributes))
             };
         }
 

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
@@ -34,12 +34,10 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-attribute-to-csp", "style");
+            var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
             var fixture = CreateFixture(id, tagName, new([styleAttribute, cspAttribute]));
             var tagHelper = new AttributeHashTagHelper()
             {
-                TargetAttributeName = "style",
-                CSPHashType = CSPHashType.SHA256,
                 ViewContext = GetViewContext(),
             };
 
@@ -59,12 +57,10 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineStyleSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-attribute-to-csp", "style");
+            var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
             var fixture = CreateFixture(id, tagName, new([styleAttribute, cspAttribute]));
             var tagHelper = new AttributeHashTagHelper()
             {
-                TargetAttributeName = "style",
-                CSPHashType = CSPHashType.SHA256,
                 ViewContext = GetViewContext(),
             };
 
@@ -84,12 +80,10 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var styleAttribute = new TagHelperAttribute("style", inlineMultiLineStyleSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-attribute-to-csp", "style");
+            var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
             var fixture = CreateFixture(id, tagName, new([styleAttribute, cspAttribute]));
             var tagHelper = new AttributeHashTagHelper()
             {
-                TargetAttributeName = "style",
-                CSPHashType = CSPHashType.SHA256,
                 ViewContext = GetViewContext(),
             };
 
@@ -108,12 +102,10 @@ background: blue;
             // Arrange
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
-            var cspAttribute = new TagHelperAttribute("asp-add-attribute-to-csp", "style");
+            var cspAttribute = new TagHelperAttribute("asp-add-style-to-csp");
             var fixture = CreateFixture(id, tagName, new([cspAttribute]));
             var tagHelper = new AttributeHashTagHelper()
             {
-                TargetAttributeName = "style",
-                CSPHashType = CSPHashType.SHA256,
                 ViewContext = GetViewContext(),
             };
 
@@ -133,12 +125,10 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var inlineScriptAttribute = new TagHelperAttribute("onclick", inlineScriptSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-attribute-to-csp", "onclick");
+            var cspAttribute = new TagHelperAttribute("asp-add-onclick-to-csp");
             var fixture = CreateFixture(id, tagName, new([inlineScriptAttribute, cspAttribute]));
             var tagHelper = new AttributeHashTagHelper()
             {
-                TargetAttributeName = "onclick",
-                CSPHashType = CSPHashType.SHA256,
                 ViewContext = GetViewContext(),
             };
 
@@ -158,12 +148,10 @@ background: blue;
             var id = Guid.NewGuid().ToString();
             var tagName = "div";
             var inlineScriptAttribute = new TagHelperAttribute("onclick", inlineScriptSnippet);
-            var cspAttribute = new TagHelperAttribute("asp-add-attribute-to-csp", "onclick");
+            var cspAttribute = new TagHelperAttribute("asp-add-onclick-to-csp");
             var fixture = CreateFixture(id, tagName, new([inlineScriptAttribute, cspAttribute]));
             var tagHelper = new AttributeHashTagHelper()
             {
-                TargetAttributeName = "onclick",
-                CSPHashType = CSPHashType.SHA256,
                 ViewContext = GetViewContext(),
             };
 

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/AttributeHashTagHelperTests.cs
@@ -87,7 +87,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test
 
             // Assert
             var hash = Assert.Single(tagHelper.ViewContext.HttpContext.GetStyleCSPHashes());
-            var expected = "'sha256-Wz9o8J/ijdXtAzs95rmQ8OtBacYk6JfYTXQlM8yxIjg='";
+            var expected = "'sha256-NerDAUWfwD31YdZHveMrq0GLjsNFMwxLpZl0dPUeCcw='";
             Assert.Equal(expected, hash);
         }
 

--- a/test/RazorWebSite/Pages/Index.cshtml
+++ b/test/RazorWebSite/Pages/Index.cshtml
@@ -12,6 +12,10 @@
 
 <h3 id="message">Haha, malicious javascript blocked!</h3>
 
+<h3 asp-add-attribute-to-csp="style" style="color: red">Red: inline style working; Black: inline style blocked!</h3>
+
+<button asp-add-attribute-to-csp="onclick" onclick="alert('JS event handler is allowed by CSP unsafe-hashes')">Click me!</button>
+
 <script asp-add-content-to-csp>
     var msg = document.getElementById('message');
     msg.innerText = "@message";

--- a/test/RazorWebSite/Pages/Index.cshtml
+++ b/test/RazorWebSite/Pages/Index.cshtml
@@ -12,9 +12,9 @@
 
 <h3 id="message">Haha, malicious javascript blocked!</h3>
 
-<h3 asp-add-style-to-csp style="color: red">Red: inline style working; Black: inline style blocked!</h3>
+<h3 asp-add-csp-for-style style="color: red">Red: inline style working; Black: inline style blocked!</h3>
 
-<button asp-add-onclick-to-csp="SHA384" onclick="alert('JS event handler is allowed by CSP unsafe-hashes')">Click me!</button>
+<button asp-add-csp-for-onclick="SHA384" onclick="alert('JS event handler is allowed by CSP unsafe-hashes')">Click me!</button>
 
 <script asp-add-content-to-csp>
     var msg = document.getElementById('message');

--- a/test/RazorWebSite/Pages/Index.cshtml
+++ b/test/RazorWebSite/Pages/Index.cshtml
@@ -12,9 +12,9 @@
 
 <h3 id="message">Haha, malicious javascript blocked!</h3>
 
-<h3 asp-add-attribute-to-csp="style" style="color: red">Red: inline style working; Black: inline style blocked!</h3>
+<h3 asp-add-style-to-csp style="color: red">Red: inline style working; Black: inline style blocked!</h3>
 
-<button asp-add-attribute-to-csp="onclick" onclick="alert('JS event handler is allowed by CSP unsafe-hashes')">Click me!</button>
+<button asp-add-onclick-to-csp="SHA384" onclick="alert('JS event handler is allowed by CSP unsafe-hashes')">Click me!</button>
 
 <script asp-add-content-to-csp>
     var msg = document.getElementById('message');

--- a/test/RazorWebSite/Startup.cs
+++ b/test/RazorWebSite/Startup.cs
@@ -29,7 +29,7 @@ public class Startup
             .AddContentSecurityPolicy(builder =>
             {
                 builder.AddUpgradeInsecureRequests();
-                builder.AddDefaultSrc().Self(); 
+                builder.AddDefaultSrc().Self();
                 builder.AddConnectSrc().From("*");
                 builder.AddFontSrc().From("*");
                 builder.AddFrameAncestors().From("*");
@@ -38,8 +38,8 @@ public class Startup
                 builder.AddMediaSrc().From("*");
                 builder.AddImgSrc().From("*").Data();
                 builder.AddObjectSrc().From("*");
-                builder.AddScriptSrc().From("*").UnsafeInline().UnsafeEval();
-                builder.AddStyleSrc().From("*").UnsafeEval().UnsafeInline();
+                builder.AddScriptSrc().From("*").WithHashTagHelper().WithNonce();
+                builder.AddStyleSrc().From("*").WithHashTagHelper();
             })
             .RemoveServerHeader();
 

--- a/test/RazorWebSite/Startup.cs
+++ b/test/RazorWebSite/Startup.cs
@@ -38,8 +38,8 @@ public class Startup
                 builder.AddMediaSrc().From("*");
                 builder.AddImgSrc().From("*").Data();
                 builder.AddObjectSrc().From("*");
-                builder.AddScriptSrc().From("*").WithHashTagHelper().WithNonce();
-                builder.AddStyleSrc().From("*").WithHashTagHelper();
+                builder.AddScriptSrc().From("*").WithHashTagHelper().WithNonce().UnsafeHashes();
+                builder.AddStyleSrc().From("*").WithHashTagHelper().UnsafeHashes();
             })
             .RemoveServerHeader();
 


### PR DESCRIPTION
As discussed in #155, this adds an additonal tag helper which allows you to hash `style` attributes, and inline event handlers. A couple notes:

 * I noticed a couple typos, so I fixed those, I hope that's ok (otherwise, I can remove them from the PR)
 * the example in the test site actually didn't didn't leverage the `HashTagHelper`, as that just contained `.UnsafeInline().UnsafeEval()`, which allows all the unsafe examples in the test page
   * in order to get this to work, I added `.WithHashTagHelper()`, and `.WithNonce()`, as also documented in the `README.md`
   * what's important to mention here, is that, if you add that, you'd get CSP violations in Dev Tools of Firefox (even though they work), in Chrome, no warnings pop up!
 * you're not able to hash multiple attributes with the current implementation (see below)

### Hashing multiple attributes on the same element?

With the current implementation, only 1 occurence of the `asp-add-attribute-to-csp` is supported, after the first run, all attributes for this tag helper will be removed (as does the `HashTagHelper`). Although, you might not run into this often, but still I think it would be good to support this scenario. For example, if you have multiple inline event handlers, then you'd need to specify multiple attributes. I don't know if you can add the same attributes more than once, but it didn't seemed like it does, as Visual Studio warned about that. Next, we have a separate attribute for the hash type, so that's an attribute you share with other invocation of the same tag helper, so you wouldn't be able to remove that attribute anymore, which is sloppy.

What I'm thinking now is to still go with the approach of adding the name of the target attribute in the `asp-add-...-to-csp` attribute, and then also do that for the hash type attribute, like this:

```html
<button style="background: red"
    onclick="..."
    asp-add-style-attribute-to-csp
    csp-style-attribute-hash-type="SHA512"
    asp-add-onclick-attribute-to-csp
    csp-style-onclick-hash-type="SHA512">
    Click me!
</button>
```

Or maybe just allow for setting the hash type on that attribute itself?

```html
<button style="background: red"
    onclick="..."
    asp-add-style-attribute-to-csp
    asp-add-onclick-attribute-to-csp="SHA512">
    Click me!
</button>
```