### PR TITLE
Changed OnResponseStarting method

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
@@ -64,16 +64,14 @@ public class SecurityHeadersMiddleware
             context.SetNonce(_nonceGenerator.GetNonce(Constants.DefaultBytesInNonce));
         }
 
-        context.Response.OnStarting(OnResponseStarting, Tuple.Create(this, context, _policy));
+        context.Response.OnStarting(() => OnResponseStarting(context));
         await _next(context);
     }
 
-    private static Task OnResponseStarting(object state)
+    private Task OnResponseStarting(HttpContext context)
     {
-        var (middleware, context, policy) = (Tuple<SecurityHeadersMiddleware, HttpContext, HeaderPolicyCollection>)state;
-
-        var result = middleware.CustomHeaderService.EvaluatePolicy(context, policy);
-        middleware.CustomHeaderService.ApplyResult(context.Response, result);
+        var result = CustomHeaderService.EvaluatePolicy(context, _policy);
+        CustomHeaderService.ApplyResult(context.Response, result);
 
 #if NET451
             return Task.FromResult(true);


### PR DESCRIPTION
OnResponseStarting is no longer a static method, so we can use the _policy and CustomHeaderService properties directly instead of passing a tuple to the method with those properties. For context, we forward the object of the method that called it.

````csharp
context.Response.OnStarting(() => OnResponseStarting(context));
````
````csharp
private Task OnResponseStarting(HttpContext context) { }
````
This way, we eliminate the need for boxing and unboxing parameters.