### PR TITLE
Remove X-XSS-Protection from default headers

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
@@ -30,7 +30,6 @@ public static class HeaderPolicyCollectionExtensions
     public static HeaderPolicyCollection AddDefaultSecurityHeaders(this HeaderPolicyCollection policies)
     {
         policies.AddFrameOptionsDeny();
-        policies.AddXssProtectionBlock();
         policies.AddContentTypeOptionsNoSniff();
         policies.AddStrictTransportSecurityMaxAge();
         policies.AddReferrerPolicyStrictOriginWhenCrossOrigin();

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpSecurityHeadersMiddlewareFunctionalTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpSecurityHeadersMiddlewareFunctionalTests.cs
@@ -39,8 +39,6 @@ public class HttpSecurityHeadersMiddlewareFunctionalTests : IClassFixture<HttpSe
         header.Should().Be("nosniff");
         header = response.Headers.GetValues("X-Frame-Options").FirstOrDefault();
         header.Should().Be("DENY");
-        header = response.Headers.GetValues("X-XSS-Protection").FirstOrDefault();
-        header.Should().Be("1; mode=block");
         header = response.Headers.GetValues("Referrer-Policy").FirstOrDefault();
         header.Should().Be("strict-origin-when-cross-origin");
         header = response.Headers.GetValues("Content-Security-Policy").FirstOrDefault();

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpsSecurityHeadersMiddlewareFunctionalTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpsSecurityHeadersMiddlewareFunctionalTests.cs
@@ -42,8 +42,6 @@ public class HttpsSecurityHeadersMiddlewareFunctionalTests : IClassFixture<Https
         header.Should().Be("nosniff");
         header = response.Headers.GetValues("X-Frame-Options").FirstOrDefault();
         header.Should().Be("DENY");
-        header = response.Headers.GetValues("X-XSS-Protection").FirstOrDefault();
-        header.Should().Be("1; mode=block");
         header = response.Headers.GetValues("Referrer-Policy").FirstOrDefault();
         header.Should().Be("strict-origin-when-cross-origin");
         header = response.Headers.GetValues("Strict-Transport-Security").FirstOrDefault();

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -1842,8 +1842,6 @@ public class SecurityHeadersMiddlewareTests
         header.Should().Be("nosniff");
         header = headers.GetValues("X-Frame-Options").FirstOrDefault()!;
         header.Should().Be("DENY");
-        header = headers.GetValues("X-XSS-Protection").FirstOrDefault()!;
-        header.Should().Be("1; mode=block");
         header = headers.GetValues("Referrer-Policy").FirstOrDefault()!;
         header.Should().Be("strict-origin-when-cross-origin");
         header = headers.GetValues("Content-Security-Policy").FirstOrDefault()!;
@@ -1861,8 +1859,6 @@ public class SecurityHeadersMiddlewareTests
         header.Should().Be("nosniff");
         header = headers.GetValues("X-Frame-Options").FirstOrDefault()!;
         header.Should().Be("DENY");
-        header = headers.GetValues("X-XSS-Protection").FirstOrDefault()!;
-        header.Should().Be("1; mode=block");
         header = headers.GetValues("Strict-Transport-Security").FirstOrDefault()!;
         header.Should().Be($"max-age={StrictTransportSecurityHeader.OneYearInSeconds}");
         header = headers.GetValues("Referrer-Policy").FirstOrDefault()!;


### PR DESCRIPTION
As described on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection) the X-XSS-Protection header "can create XSS vulnerabilities in otherwise safe websites".

Fixes #141