### PR TITLE
Make adding directives to the CSP idempotent to avoid duplicates

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspDirectiveBuilderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspDirectiveBuilderExtensions.cs
@@ -251,7 +251,9 @@ public static class CspDirectiveBuilderExtensions
     public static T WithNonce<T>(this T builder) where T : CspDirectiveBuilder
     {
         // The format parameter will be replaced with the nonce for each request
-        builder.SourceBuilders.Add(ctx => $"'nonce-{ctx.GetNonce()}'");
+        builder.SourceBuilders.Add(
+            ctx => $"'nonce-{ctx.GetNonce()}'",
+            $"{typeof(T).FullName}.{nameof(WithNonce)}");
         return builder;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameAncestorsDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameAncestorsDirectiveBuilder.cs
@@ -21,7 +21,7 @@ public class FrameAncestorsDirectiveBuilder : CspDirectiveBuilderBase
     /// <summary>
     /// The sources from which the directive is allowed.
     /// </summary>
-    public List<string> Sources { get; } = new List<string>();
+    public SourceCollection Sources { get; } = new();
 
     /// <summary>
     /// If true, no sources are allowed.

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceAttrDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceAttrDirectiveBuilder.cs
@@ -36,10 +36,9 @@ public class ScriptSourceAttrDirectiveBuilder : CspDirectiveBuilder
     public ScriptSourceAttrDirectiveBuilder WithHashTagHelper()
     {
         // TODO: check hash algorithm is one of expected values
-        SourceBuilders.Add(ctx =>
-        {
-            return string.Join(" ", ctx.GetScriptCSPHashes());
-        });
+        SourceBuilders.Add(
+            ctx => string.Join(" ", ctx.GetScriptCSPHashes()),
+            $"{nameof(ScriptSourceAttrDirectiveBuilder)}.{nameof(WithHashTagHelper)}");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceDirectiveBuilder.cs
@@ -32,10 +32,9 @@ public class ScriptSourceDirectiveBuilder : CspDirectiveBuilder
     public ScriptSourceDirectiveBuilder WithHashTagHelper()
     {
         // TODO: check hash algorithm is one of expected values
-        SourceBuilders.Add(ctx =>
-        {
-            return string.Join(" ", ctx.GetScriptCSPHashes());
-        });
+        SourceBuilders.Add(
+            ctx => string.Join(" ", ctx.GetScriptCSPHashes()),
+            $"{nameof(ScriptSourceDirectiveBuilder)}.{nameof(WithHashTagHelper)}");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceElemDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceElemDirectiveBuilder.cs
@@ -36,10 +36,9 @@ public class ScriptSourceElemDirectiveBuilder : CspDirectiveBuilder
     public ScriptSourceElemDirectiveBuilder WithHashTagHelper()
     {
         // TODO: check hash algorithm is one of expected values
-        SourceBuilders.Add(ctx =>
-        {
-            return string.Join(" ", ctx.GetScriptCSPHashes());
-        });
+        SourceBuilders.Add(
+            ctx => string.Join(" ", ctx.GetScriptCSPHashes()),
+            $"{nameof(ScriptSourceElemDirectiveBuilder)}.{nameof(WithHashTagHelper)}");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceAttrDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceAttrDirectiveBuilder.cs
@@ -33,10 +33,9 @@ public class StyleSourceAttrDirectiveBuilder : CspDirectiveBuilder
     public StyleSourceAttrDirectiveBuilder WithHashTagHelper()
     {
         // TODO: check hash algorithm is one of expected values
-        SourceBuilders.Add(ctx =>
-        {
-            return string.Join(" ", ctx.GetStyleCSPHashes());
-        });
+        SourceBuilders.Add(
+            ctx => string.Join(" ", ctx.GetStyleCSPHashes()),
+            $"{nameof(StyleSourceAttrDirectiveBuilder)}.{nameof(WithHashTagHelper)}");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
@@ -30,10 +30,9 @@ public class StyleSourceDirectiveBuilder : CspDirectiveBuilder
     public StyleSourceDirectiveBuilder WithHashTagHelper()
     {
         // TODO: check hash algorithm is one of expected values
-        SourceBuilders.Add(ctx =>
-        {
-            return string.Join(" ", ctx.GetStyleCSPHashes());
-        });
+        SourceBuilders.Add(
+            ctx => string.Join(" ", ctx.GetStyleCSPHashes()),
+            $"{nameof(StyleSourceDirectiveBuilder)}.{nameof(WithHashTagHelper)}");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceElemDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceElemDirectiveBuilder.cs
@@ -34,10 +34,9 @@ public class StyleSourceElemDirectiveBuilder : CspDirectiveBuilder
     public StyleSourceElemDirectiveBuilder WithHashTagHelper()
     {
         // TODO: check hash algorithm is one of expected values
-        SourceBuilders.Add(ctx =>
-        {
-            return string.Join(" ", ctx.GetStyleCSPHashes());
-        });
+        SourceBuilders.Add(
+            ctx => string.Join(" ", ctx.GetStyleCSPHashes()),
+            $"{nameof(StyleSourceElemDirectiveBuilder)}.{nameof(WithHashTagHelper)}");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/FeaturePolicy/FeaturePolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/FeaturePolicy/FeaturePolicyDirectiveBuilder.cs
@@ -19,7 +19,7 @@ public class FeaturePolicyDirectiveBuilder : FeaturePolicyDirectiveBuilderBase
     /// <summary>
     /// The sources from which the directive is allowed.
     /// </summary>
-    public List<string> Sources { get; } = new List<string>();
+    public SourceCollection Sources { get; } = new();
 
     /// <summary>
     /// If true, no sources are allowed.

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyDirectiveBuilder.cs
@@ -20,7 +20,7 @@ public abstract class PermissionsPolicyDirectiveBuilder : PermissionsPolicyDirec
     /// <summary>
     /// The sources from which the directive is allowed.
     /// </summary>
-    public List<string> Sources { get; } = new List<string>();
+    public SourceCollection Sources { get; } = new();
 
     /// <summary>
     /// If true, no sources are allowed.

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/SourceBuilderCollection.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/SourceBuilderCollection.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers;
+
+/// <summary>
+/// A collection of source builders for a given directive
+/// </summary>
+internal class SourceBuilderCollection
+{
+    private HashSet<string>? _keys;
+    private List<Func<HttpContext, string>>? _sourceBuilders;
+
+    /// <summary>
+    /// Adds a source builder to the collection for the given directive
+    /// Calls to <see cref="Add"/> are idempotent for a given <paramref name="key"/>
+    /// if the builder with the provided key has already been added, it will not be added again.
+    /// </summary>
+    /// <param name="builder">The builder to add</param>
+    /// <param name="key">The key for the builder used to determine uniqueness</param>
+    public void Add(Func<HttpContext, string> builder, string key)
+    {
+        _keys ??= [];
+        if (_keys.Add(key))
+        {
+            _sourceBuilders ??= [];
+            _sourceBuilders.Add(builder);
+        }
+    }
+
+    /// <summary>
+    /// Creates a copy of the list of builders
+    /// </summary>
+    /// <returns>A copy of the list of builders</returns>
+    public List<Func<HttpContext, string>> ToList() => _sourceBuilders?.ToList() ?? [];
+
+    /// <summary>
+    /// Have any builders been added?
+    /// </summary>
+    /// <returns>True if any builders have been added</returns>
+    public bool Any() => _sourceBuilders?.Count > 0;
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/SourceCollection.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/SourceCollection.cs
@@ -1,0 +1,46 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers;
+
+/// <summary>
+/// A collection of sources for a given directive
+/// </summary>
+public class SourceCollection : IEnumerable<string>
+{
+    private readonly List<string> _sources = [];
+
+    /// <summary>
+    /// Gets the number of elements in the source collection
+    /// </summary>
+    public int Count => _sources.Count;
+
+    /// <summary>
+    /// Adds a source to the collection for the given directive.
+    /// Calls to <see cref="Add"/> are idempotent;
+    /// if the source has already been added, it will not be added again.
+    /// </summary>
+    /// <param name="source">The source to add</param>
+    public void Add(string source)
+    {
+        if (!_sources.Contains(source))
+        {
+            _sources.Add(source);
+        }
+    }
+
+    /// <summary>
+    /// Removes a source from the collection for the given directive.
+    /// Returns true if the source was removed. Returns false if the
+    /// source was not found in the collection.
+    /// </summary>
+    /// <param name="source">The source to remove</param>
+    /// <returns>True if the source was found and removed, false if it was not found.</returns>
+    public bool Remove(string source) => _sources.Remove(source);
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <inheritdoc/>
+    public IEnumerator<string> GetEnumerator() => _sources.GetEnumerator();
+}


### PR DESCRIPTION
This is a breaking change in the API of `CspDirectiveBuilder.Sources`, `FeaturePolicyDirectiveBuilder.Sources`, and `PermissionsPolicyDirectiveBuilder.Sources` to make them idempotent

Fixes #147 