### PR TITLE
Endpoint security middleware

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/EndpointSecurityHeadersMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/EndpointSecurityHeadersMiddleware.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using NetEscapades.AspNetCore.SecurityHeaders.Headers;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders;
+
+/// <summary>
+/// An ASP.NET Core middleware for adding security headers.
+/// </summary>
+internal class EndpointSecurityHeadersMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<EndpointSecurityHeadersMiddleware> _logger;
+    private readonly CustomHeaderOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EndpointSecurityHeadersMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="logger">A logger for recording errors.</param>
+    /// <param name="options">Options on how to control the settings that are applied</param>
+    public EndpointSecurityHeadersMiddleware(RequestDelegate next, ILogger<EndpointSecurityHeadersMiddleware> logger, CustomHeaderOptions options)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+        _logger = logger;
+        _options = options;
+    }
+
+    /// <summary>
+    /// Invoke the middleware
+    /// </summary>
+    /// <param name="context">The current context</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public Task Invoke(HttpContext context)
+    {
+        // Policy resolution rules:
+        //
+        // 1. If there is an endpoint with a named policy, then fetch that policy
+        // 2. Use the provided default policy
+        var endpoint = context.GetEndpoint();
+        var metadata = endpoint?.Metadata.GetMetadata<ISecurityHeadersPolicyMetadata>();
+
+        if (!string.IsNullOrEmpty(metadata?.PolicyName))
+        {
+            if (_options.GetPolicy(metadata.PolicyName) is { } namedPolicy)
+            {
+                context.Items[SecurityHeadersMiddleware.HttpContextKey] = namedPolicy;
+            }
+            else
+            {
+                // log that we couldn't find the policy
+                _logger.LogWarning(
+                    "Error configuring security headers middleware: policy '{PolicyName}' could not be found. "
+                    + "Configure the policies for your application by calling AddSecurityHeaderPolicies() on IServiceCollection "
+                    + "and adding a policy with the required name.",
+                    metadata.PolicyName);
+            }
+        }
+
+        return _next(context);
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
@@ -221,11 +221,9 @@ public class CspBuilderTests
 
         var result = builder.Build();
 
-        result.Invoking(x =>
-            {
-                var val = x.ConstantValue;
-            })
-            .ShouldThrow<InvalidOperationException>();
+        result.Invoking(x=>x.ConstantValue)
+            .Should()
+            .Throw<InvalidOperationException>();
     }
     [Theory]
     [InlineData(true, false)]
@@ -272,11 +270,9 @@ public class CspBuilderTests
 
         var result = builder.Build();
 
-        result.Invoking(x =>
-            {
-                var val = x.Builder;
-            })
-            .ShouldThrow<InvalidOperationException>();
+        result.Invoking(x=>x.Builder)
+            .Should()
+            .Throw<InvalidOperationException>();
     }
 
     [Fact]

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpSecurityHeadersMiddlewareFunctionalTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpSecurityHeadersMiddlewareFunctionalTests.cs
@@ -58,7 +58,7 @@ public class HttpSecurityHeadersMiddlewareFunctionalTests : IClassFixture<HttpSe
         content.Should().Be(expected);
 
         // no security headers
-        response.Headers.Should().NotContain("X-Frame-Options");
+        response.Headers.Should().NotContainKey("X-Frame-Options");
         response.Headers.TryGetValues("Custom-Header", out var customHeader).Should().BeTrue();
         customHeader.Should().ContainSingle("MyValue");
     }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpsSecurityHeadersMiddlewareFunctionalTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HttpsSecurityHeadersMiddlewareFunctionalTests.cs
@@ -59,7 +59,7 @@ public class HttpsSecurityHeadersMiddlewareFunctionalTests : IClassFixture<Https
         content.Should().Be(expected);
 
         // no security headers
-        response.Headers.Should().NotContain("X-Frame-Options");
+        response.Headers.Should().NotContainKey("X-Frame-Options");
         response.Headers.TryGetValues("Custom-Header", out var customHeader).Should().BeTrue();
         customHeader.Should().ContainSingle("MyValue");
     }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/NetEscapades.AspNetCore.SecurityHeaders.Test.csproj
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/NetEscapades.AspNetCore.SecurityHeaders.Test.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/test/SecurityHeadersMiddlewareWebSite/Startup.cs
+++ b/test/SecurityHeadersMiddlewareWebSite/Startup.cs
@@ -23,7 +23,7 @@ public class Startup
     {
         app.UseSecurityHeaders();
         app.UseRouting();
-        app.UseSecurityHeaders();
+        app.UseEndpointSecurityHeaders();
         app.UseEndpoints(endpoints =>
         {
             endpoints.MapGet("/custom", context => context.Response.WriteAsync("Hello World!"))


### PR DESCRIPTION
Make some changes to the design of the endpoint-specific endpoints work in #172 . tl;dr; call `UseSecurityHeaders()` as before, at the start of the middleware pipeline, and then call `UseEndpointSecurityHeaders()` after `UseRouting()`.

I think this is preferable as it's much easier to explain and reason about, and we don't have to worry about "overrides" so much etc