### PR TITLE
Allow cutsomizing the headers per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ To customize the final `HeaderPolicyCollection` used for a request, you can use 
 - `SetDefaultPolicySelector(policySelector)`&mdash;used to choose the `HeaderPolicyCollection` applied for default requests.
 - `SetEndpointPolicySelector(policySelector)`&mdash;used to choose the `HeaderPolicyCollection` applied when an endpoint-specific named policy is selected. 
 
-Both methods take a `Func<>` argument which is passed a context object, and must return a `HeaderPolicyCollection`. The `SetDefaultPolicySelector()` argument is invoked for every request, when the default policy is applied, and allows you to change the `HeaderPolicyCollection` to apply.  The `SetEndpointPolicySelector()` argument is only invoked when an endpoint-specific named policy is selected.
+Both methods take a `Func<>` argument which is passed a context object, and must return an `IReadOnlyHeaderPolicyCollection`. The `SetDefaultPolicySelector()` argument is invoked for every request, when the default policy is applied, and allows you to change the `IReadOnlyHeaderPolicyCollection` to apply.  The `SetEndpointPolicySelector()` argument is only invoked when an endpoint-specific named policy is selected.
 
 The following code shows how to use services inside the `SetDefaultPolicySelector()` method. This isn't necessary, but rather shows that you can completely customise the applied headers in any way you need to.
 
@@ -279,6 +279,8 @@ builder.Services.AddSecurityHeaderPolicies()
         return selector.GetPolicy(tenant);
     };
 ```
+
+Note that you should avoid creating a `HeaderPolicyCollection` from scratch on each request. Instead, cache policies for multiple requests where possible. However, if you need to build a new policy based on the policy passed in the context object, you can create a mutable copy by calling `IReadOnlyHeaderPolicyCollection.Copy()`, adding/updating policies as required, and returning the `HeaderPolicyCollection`. 
 
 ## RemoveServerHeader
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ app.UseStaticFiles();
 app.UseAuthentication();
 app.UseRouting(); 
 
-app.UseSecurityHeaders(); 
+app.UseEndpointSecurityHeaders(); 
 app.UseAuthorization();
 
 app.MapGet("/", () => "Hello world")
@@ -247,6 +247,38 @@ Security headers are applied just before the response is sent. If you use the co
 2. If a named or policy instance is passed to the `SecurityHeadersMiddleware()`, use that.
 3. If the default policy has been set using `SetDefaultPolicy()`, use that.
 4. Otherwise, apply the default headers (those added by `AddDefaultSecurityHeaders()`)
+
+## Customizing the headers per request
+
+If you need to use a different set of security headers for certain endpoints in your application, then configuring named policies and calling `UseEndpointSecurityHeaders()` as (described)[#pplying-different-headers-to-different-endpoints] above is the best approach.
+
+However, sometimes you need even more customization on a per-request basis. For example, perhaps you have a multi-tenant application, and you need to apply different headers based on a header in the request that identifies the tenant. In this situation, you don't know at application startup which set of headers to apply. 
+
+To customize the final `HeaderPolicyCollection` used for a request, you can use two methods available on `IServiceCollection.s.AddSecurityHeaderPolicies()`:
+
+- `SetDefaultPolicySelector(policySelector)`&mdash;used to choose the `HeaderPolicyCollection` applied for default requests.
+- `SetEndpointPolicySelector(policySelector)`&mdash;used to choose the `HeaderPolicyCollection` applied when an endpoint-specific named policy is selected. 
+
+Both methods take a `Func<>` argument which is passed a context object, and must return a `HeaderPolicyCollection`. The `SetDefaultPolicySelector()` argument is invoked for every request, when the default policy is applied, and allows you to change the `HeaderPolicyCollection` to apply.  The `SetEndpointPolicySelector()` argument is only invoked when an endpoint-specific named policy is selected.
+
+The following code shows how to use services inside the `SetDefaultPolicySelector()` method. This isn't necessary, but rather shows that you can completely customise the applied headers in any way you need to.
+
+```csharp
+var builder = WebApplication.CreateBuilder();
+
+// 👇 a custom service that selects the policy based on tenants
+builder.Services.AddScoped<TenantHeaderPolicyCollectionSelector>(); 
+builder.Services.AddSecurityHeaderPolicies()
+    .AddPolicy(policyName, p => p.AddCustomHeader("Custom-Header", "MyValue"))
+    .SetDefaultPolicySelector((DefaultPolicySelectorContext ctx) =>
+    {
+        // Use services from the DI container (if you need to)
+        IServiceProvider services = ctx.HttpContext.RequestServices; 
+        var selector = services.GetService<TenantHeaderPolicyCollectionSelector>();
+        var tenant = services.GetService<ITenant>();
+        return selector.GetPolicy(tenant);
+    };
+```
 
 ## RemoveServerHeader
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/EndpointSecurityHeadersMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/EndpointSecurityHeadersMiddleware.cs
@@ -17,6 +17,7 @@ internal class EndpointSecurityHeadersMiddleware
     private readonly RequestDelegate _next;
     private readonly ILogger<EndpointSecurityHeadersMiddleware> _logger;
     private readonly CustomHeaderOptions _options;
+    private readonly Func<EndpointPolicySelectorContext, HeaderPolicyCollection>? _policySelector;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EndpointSecurityHeadersMiddleware"/> class.
@@ -29,6 +30,7 @@ internal class EndpointSecurityHeadersMiddleware
         _next = next ?? throw new ArgumentNullException(nameof(next));
         _logger = logger;
         _options = options;
+        _policySelector = _options.EndpointPolicySelector;
     }
 
     /// <summary>
@@ -44,12 +46,18 @@ internal class EndpointSecurityHeadersMiddleware
         // 2. Use the provided default policy
         var endpoint = context.GetEndpoint();
         var metadata = endpoint?.Metadata.GetMetadata<ISecurityHeadersPolicyMetadata>();
+        var policyName = metadata?.PolicyName;
 
-        if (!string.IsNullOrEmpty(metadata?.PolicyName))
+        if (!string.IsNullOrEmpty(policyName))
         {
-            if (_options.GetPolicy(metadata.PolicyName) is { } namedPolicy)
+            if (_options.GetPolicy(policyName) is { } policyToApply)
             {
-                context.Items[SecurityHeadersMiddleware.HttpContextKey] = namedPolicy;
+                if (_policySelector is not null)
+                {
+                    policyToApply = _policySelector(new(context, policyName, policyToApply));
+                }
+
+                context.Items[SecurityHeadersMiddleware.HttpContextKey] = policyToApply;
             }
             else
             {
@@ -58,7 +66,7 @@ internal class EndpointSecurityHeadersMiddleware
                     "Error configuring security headers middleware: policy '{PolicyName}' could not be found. "
                     + "Configure the policies for your application by calling AddSecurityHeaderPolicies() on IServiceCollection "
                     + "and adding a policy with the required name.",
-                    metadata.PolicyName);
+                    policyName);
             }
         }
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/EndpointSecurityHeadersMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/EndpointSecurityHeadersMiddleware.cs
@@ -17,7 +17,7 @@ internal class EndpointSecurityHeadersMiddleware
     private readonly RequestDelegate _next;
     private readonly ILogger<EndpointSecurityHeadersMiddleware> _logger;
     private readonly CustomHeaderOptions _options;
-    private readonly Func<EndpointPolicySelectorContext, HeaderPolicyCollection>? _policySelector;
+    private readonly Func<EndpointPolicySelectorContext, IReadOnlyHeaderPolicyCollection>? _policySelector;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EndpointSecurityHeadersMiddleware"/> class.
@@ -50,7 +50,7 @@ internal class EndpointSecurityHeadersMiddleware
 
         if (!string.IsNullOrEmpty(policyName))
         {
-            if (_options.GetPolicy(policyName) is { } policyToApply)
+            if (_options.GetPolicy(policyName) is IReadOnlyHeaderPolicyCollection policyToApply)
             {
                 if (_policySelector is not null)
                 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollection.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollection.cs
@@ -11,6 +11,20 @@ namespace Microsoft.AspNetCore.Builder;
 public class HeaderPolicyCollection : Dictionary<string, IHeaderPolicy>
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="HeaderPolicyCollection"/> class.
+    /// </summary>
+    public HeaderPolicyCollection()
+    {
+    }
+
+    private HeaderPolicyCollection(HeaderPolicyCollection other)
+        : base(other)
+    {
+        DocumentHeaderContentTypePrefixes =
+            other.DocumentHeaderContentTypePrefixes is { } prefixes ? [..prefixes] : null;
+    }
+
+    /// <summary>
     /// The content types that document-based headers such as Content-Security-Policy should apply to
     /// </summary>
     internal string[]? DocumentHeaderContentTypePrefixes { get; set; } = { "text/html", "application/javascript", "text/javascript" };
@@ -50,4 +64,11 @@ public class HeaderPolicyCollection : Dictionary<string, IHeaderPolicy>
 
         return this;
     }
+
+    /// <summary>
+    /// Creates a copy of the header collection
+    /// </summary>
+    /// <returns>A shallow copy of the header policy</returns>
+    public HeaderPolicyCollection Copy()
+        => new(this);
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollection.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollection.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using NetEscapades.AspNetCore.SecurityHeaders;
 using NetEscapades.AspNetCore.SecurityHeaders.Headers;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.AspNetCore.Builder;
@@ -8,7 +10,7 @@ namespace Microsoft.AspNetCore.Builder;
 /// <summary>
 /// Defines the policies to use for customising security headers for a request.
 /// </summary>
-public class HeaderPolicyCollection : Dictionary<string, IHeaderPolicy>
+public class HeaderPolicyCollection : Dictionary<string, IHeaderPolicy>, IReadOnlyHeaderPolicyCollection
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="HeaderPolicyCollection"/> class.
@@ -17,7 +19,11 @@ public class HeaderPolicyCollection : Dictionary<string, IHeaderPolicy>
     {
     }
 
-    private HeaderPolicyCollection(HeaderPolicyCollection other)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HeaderPolicyCollection"/> class.
+    /// </summary>
+    /// <param name="other">The <see cref="IReadOnlyHeaderPolicyCollection"/> policies to copy</param>
+    internal HeaderPolicyCollection(IReadOnlyHeaderPolicyCollection other)
         : base(other)
     {
         DocumentHeaderContentTypePrefixes =
@@ -28,6 +34,9 @@ public class HeaderPolicyCollection : Dictionary<string, IHeaderPolicy>
     /// The content types that document-based headers such as Content-Security-Policy should apply to
     /// </summary>
     internal string[]? DocumentHeaderContentTypePrefixes { get; set; } = { "text/html", "application/javascript", "text/javascript" };
+
+    /// <inheritdoc/>
+    ICollection<string>? IReadOnlyHeaderPolicyCollection.DocumentHeaderContentTypePrefixes => DocumentHeaderContentTypePrefixes;
 
     /// <summary>
     /// Apply document-based headers such as Content-Security-Policy to all responses serving the provided
@@ -64,11 +73,4 @@ public class HeaderPolicyCollection : Dictionary<string, IHeaderPolicy>
 
         return this;
     }
-
-    /// <summary>
-    /// Creates a copy of the header collection
-    /// </summary>
-    /// <returns>A shallow copy of the header policy</returns>
-    public HeaderPolicyCollection Copy()
-        => new(this);
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
@@ -1,4 +1,6 @@
+using NetEscapades.AspNetCore.SecurityHeaders;
 using NetEscapades.AspNetCore.SecurityHeaders.Headers;
+using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.AspNetCore.Builder;
@@ -21,6 +23,14 @@ public static class HeaderPolicyCollectionExtensions
         policies[policy.Header] = policy;
         return policies;
     }
+
+    /// <summary>
+    /// Creates a copy of the header collection
+    /// </summary>
+    /// <param name="policies">The <see cref="IReadOnlyHeaderPolicyCollection" /> to copy</param>
+    /// <returns>A new <see cref="HeaderPolicyCollection"/> that is a shallow copy of the header policy</returns>
+    public static HeaderPolicyCollection Copy(this IReadOnlyHeaderPolicyCollection policies)
+        => new(policies);
 
     /// <summary>
     /// Add default headers in accordance with the most secure approach

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/DocumentHeaderPolicyBase.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/DocumentHeaderPolicyBase.cs
@@ -1,5 +1,5 @@
 using System;
-using Microsoft.AspNetCore.Builder;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
 
@@ -19,7 +19,7 @@ public abstract class DocumentHeaderPolicyBase : HeaderPolicyBase, IDocumentHead
     }
 
     /// <inheritdoc />
-    public void Apply(HttpContext context, CustomHeadersResult result, HeaderPolicyCollection policies)
+    public void Apply(HttpContext context, CustomHeadersResult result, IReadOnlyHeaderPolicyCollection policies)
     {
         if (context == null)
         {
@@ -41,7 +41,7 @@ public abstract class DocumentHeaderPolicyBase : HeaderPolicyBase, IDocumentHead
         }
     }
 
-    private static bool IsMatch(HttpContext context, string[] contentTypes)
+    private static bool IsMatch(HttpContext context, ICollection<string> contentTypes)
     {
         foreach (var contentTypePrefix in contentTypes)
         {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/IDocumentHeaderPolicy.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/IDocumentHeaderPolicy.cs
@@ -16,5 +16,5 @@ internal interface IDocumentHeaderPolicy : IHeaderPolicy
     /// <param name="context">The <see cref="HttpContext"/> associated with the current call.</param>
     /// <param name="result">The <see cref="CustomHeadersResult"/> to update.</param>
     /// <param name="policies">The <see cref="HeaderPolicyCollection"/> applied to the request</param>
-    void Apply(HttpContext context, CustomHeadersResult result, HeaderPolicyCollection policies);
+    void Apply(HttpContext context, CustomHeadersResult result, IReadOnlyHeaderPolicyCollection policies);
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderOptions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderOptions.cs
@@ -23,12 +23,12 @@ internal class CustomHeaderOptions
     /// <summary>
     /// The default policy selector function
     /// </summary>
-    public Func<DefaultPolicySelectorContext, HeaderPolicyCollection>? DefaultPolicySelector { get; set; }
+    public Func<DefaultPolicySelectorContext, IReadOnlyHeaderPolicyCollection>? DefaultPolicySelector { get; set; }
 
     /// <summary>
     /// The endpoint policy selector function
     /// </summary>
-    public Func<EndpointPolicySelectorContext, HeaderPolicyCollection>? EndpointPolicySelector { get; set; }
+    public Func<EndpointPolicySelectorContext, IReadOnlyHeaderPolicyCollection>? EndpointPolicySelector { get; set; }
 
     /// <summary>
     /// Gets the policy based on the <paramref name="name"/>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderOptions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderOptions.cs
@@ -21,6 +21,16 @@ internal class CustomHeaderOptions
     public HeaderPolicyCollection? DefaultPolicy { get; set; }
 
     /// <summary>
+    /// The default policy selector function
+    /// </summary>
+    public Func<DefaultPolicySelectorContext, HeaderPolicyCollection>? DefaultPolicySelector { get; set; }
+
+    /// <summary>
+    /// The endpoint policy selector function
+    /// </summary>
+    public Func<EndpointPolicySelectorContext, HeaderPolicyCollection>? EndpointPolicySelector { get; set; }
+
+    /// <summary>
     /// Gets the policy based on the <paramref name="name"/>
     /// </summary>
     /// <param name="name">The name of the policy to lookup.</param>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderService.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderService.cs
@@ -17,7 +17,7 @@ internal static class CustomHeaderService
     /// <param name="policies">The <see cref="HeaderPolicyCollection"/> containing policies to be evaluated.</param>
     /// <returns>A <see cref="CustomHeadersResult"/> which contains the result of policy evaluation and can be
     /// used by the caller to set appropriate response headers.</returns>
-    public static CustomHeadersResult EvaluatePolicy(HttpContext context, HeaderPolicyCollection policies)
+    public static CustomHeadersResult EvaluatePolicy(HttpContext context, IReadOnlyHeaderPolicyCollection policies)
     {
         if (context == null)
         {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/DefaultPolicySelectorContext.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/DefaultPolicySelectorContext.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+/// <summary>
+/// A context object used during policy selection
+/// </summary>
+public readonly struct DefaultPolicySelectorContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultPolicySelectorContext"/> struct.
+    /// </summary>
+    /// <param name="httpContext">The current <see cref="HttpContext"/> for the request</param>
+    /// <param name="defaultPolicy">The default policy to apply to the request</param>
+    internal DefaultPolicySelectorContext(HttpContext httpContext, HeaderPolicyCollection defaultPolicy)
+    {
+        HttpContext = httpContext;
+        DefaultPolicy = defaultPolicy;
+    }
+
+    /// <summary>
+    /// The current <see cref="HttpContext"/> for the request
+    /// </summary>
+    public HttpContext HttpContext { get; }
+
+    /// <summary>
+    /// The default policy that will applied to the request
+    /// </summary>
+    public HeaderPolicyCollection DefaultPolicy { get; }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/DefaultPolicySelectorContext.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/DefaultPolicySelectorContext.cs
@@ -25,7 +25,7 @@ public readonly struct DefaultPolicySelectorContext
     public HttpContext HttpContext { get; }
 
     /// <summary>
-    /// The default policy that will applied to the request
+    /// The default policy that will be applied to the request
     /// </summary>
-    public HeaderPolicyCollection DefaultPolicy { get; }
+    public IReadOnlyHeaderPolicyCollection DefaultPolicy { get; }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/EndpointPolicySelectorContext.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/EndpointPolicySelectorContext.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+/// <summary>
+/// A context object used during policy selection
+/// </summary>
+public readonly struct EndpointPolicySelectorContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EndpointPolicySelectorContext"/> struct.
+    /// </summary>
+    /// <param name="httpContext">The current <see cref="HttpContext"/> for the request</param>
+    /// <param name="selectedPolicyName">The name of the selected policy for the endpoint</param>
+    /// <param name="selectedPolicy">The selected policy for the endpoint</param>
+    internal EndpointPolicySelectorContext(HttpContext httpContext, string selectedPolicyName, HeaderPolicyCollection selectedPolicy)
+    {
+        HttpContext = httpContext;
+        SelectedPolicyName = selectedPolicyName;
+        SelectedPolicy = selectedPolicy;
+    }
+
+    /// <summary>
+    /// The current <see cref="HttpContext"/> for the request
+    /// </summary>
+    public HttpContext HttpContext { get; }
+
+    /// <summary>
+    /// The name of the selected policy for the endpoint
+    /// </summary>
+    public string SelectedPolicyName { get; }
+
+    /// <summary>
+    /// The selected policy for the endpoint
+    /// </summary>
+    public HeaderPolicyCollection SelectedPolicy { get; }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/EndpointPolicySelectorContext.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/EndpointPolicySelectorContext.cs
@@ -14,7 +14,7 @@ public readonly struct EndpointPolicySelectorContext
     /// <param name="httpContext">The current <see cref="HttpContext"/> for the request</param>
     /// <param name="selectedPolicyName">The name of the selected policy for the endpoint</param>
     /// <param name="selectedPolicy">The selected policy for the endpoint</param>
-    internal EndpointPolicySelectorContext(HttpContext httpContext, string selectedPolicyName, HeaderPolicyCollection selectedPolicy)
+    internal EndpointPolicySelectorContext(HttpContext httpContext, string selectedPolicyName, IReadOnlyHeaderPolicyCollection selectedPolicy)
     {
         HttpContext = httpContext;
         SelectedPolicyName = selectedPolicyName;
@@ -34,5 +34,5 @@ public readonly struct EndpointPolicySelectorContext
     /// <summary>
     /// The selected policy for the endpoint
     /// </summary>
-    public HeaderPolicyCollection SelectedPolicy { get; }
+    public IReadOnlyHeaderPolicyCollection SelectedPolicy { get; }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/IReadOnlyHeaderPolicyCollection.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/IReadOnlyHeaderPolicyCollection.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Builder;
+using NetEscapades.AspNetCore.SecurityHeaders.Headers;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
+
+/// <summary>
+/// A readonly view of a <see cref="HeaderPolicyCollection"/>
+/// </summary>
+public interface IReadOnlyHeaderPolicyCollection : IReadOnlyDictionary<string, IHeaderPolicy>
+{
+    /// <summary>
+    /// The content types that document-based headers such as Content-Security-Policy should apply to
+    /// </summary>
+    internal ICollection<string>? DocumentHeaderContentTypePrefixes { get; }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/SecurityHeaderPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/SecurityHeaderPolicyBuilder.cs
@@ -80,7 +80,7 @@ public class SecurityHeaderPolicyBuilder
     /// to select the policy to use. The final policy to execute should be returned from the function.</param>
     /// <returns>The <see cref="SecurityHeaderPolicyBuilder"/> for chaining</returns>
     public SecurityHeaderPolicyBuilder SetDefaultPolicySelector(
-        Func<DefaultPolicySelectorContext, HeaderPolicyCollection> policySelector)
+        Func<DefaultPolicySelectorContext, IReadOnlyHeaderPolicyCollection> policySelector)
     {
         _options.DefaultPolicySelector = policySelector;
         return this;
@@ -94,7 +94,7 @@ public class SecurityHeaderPolicyBuilder
     /// to select the policy to use. The final policy to execute should be returned from the function.</param>
     /// <returns>The <see cref="SecurityHeaderPolicyBuilder"/> for chaining</returns>
     public SecurityHeaderPolicyBuilder SetEndpointPolicySelector(
-        Func<EndpointPolicySelectorContext, HeaderPolicyCollection> policySelector)
+        Func<EndpointPolicySelectorContext, IReadOnlyHeaderPolicyCollection> policySelector)
     {
         _options.EndpointPolicySelector = policySelector;
         return this;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/SecurityHeaderPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/SecurityHeaderPolicyBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 
 namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
 
@@ -68,6 +69,34 @@ public class SecurityHeaderPolicyBuilder
     public SecurityHeaderPolicyBuilder SetDefaultPolicy(HeaderPolicyCollection policyCollection)
     {
         _options.DefaultPolicy = policyCollection;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the policy selector. Use this to customise what is the default policy selected for a given request.
+    /// This is invoked for every request.
+    /// </summary>
+    /// <param name="policySelector">A function to invoke when the <see cref="SecurityHeadersMiddleware"/> executes,
+    /// to select the policy to use. The final policy to execute should be returned from the function.</param>
+    /// <returns>The <see cref="SecurityHeaderPolicyBuilder"/> for chaining</returns>
+    public SecurityHeaderPolicyBuilder SetDefaultPolicySelector(
+        Func<DefaultPolicySelectorContext, HeaderPolicyCollection> policySelector)
+    {
+        _options.DefaultPolicySelector = policySelector;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the policy selector. Use this to customise which policy is selected for a given endpoint.
+    /// This is only called  when an endpoint-specific policy is selected.
+    /// </summary>
+    /// <param name="policySelector">A function to invoke when the <see cref="EndpointSecurityHeadersMiddleware"/> executes,
+    /// to select the policy to use. The final policy to execute should be returned from the function.</param>
+    /// <returns>The <see cref="SecurityHeaderPolicyBuilder"/> for chaining</returns>
+    public SecurityHeaderPolicyBuilder SetEndpointPolicySelector(
+        Func<EndpointPolicySelectorContext, HeaderPolicyCollection> policySelector)
+    {
+        _options.EndpointPolicySelector = policySelector;
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
@@ -22,15 +22,21 @@ internal class SecurityHeadersMiddleware
     private readonly RequestDelegate _next;
     private readonly HeaderPolicyCollection _defaultPolicy;
     private readonly NonceGenerator? _nonceGenerator;
+    private readonly Func<DefaultPolicySelectorContext, HeaderPolicyCollection> _policySelector;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SecurityHeadersMiddleware"/> class.
     /// </summary>
     /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="policySelector">An optional function to execute to change the policy prior to applying</param>
     /// <param name="defaultPolicy">A <see cref="HeaderPolicyCollection"/> containing the policy to apply by default.</param>
-    public SecurityHeadersMiddleware(RequestDelegate next, HeaderPolicyCollection defaultPolicy)
+    public SecurityHeadersMiddleware(
+        RequestDelegate next,
+        Func<DefaultPolicySelectorContext, HeaderPolicyCollection> policySelector,
+        HeaderPolicyCollection defaultPolicy)
     {
         _next = next ?? throw new ArgumentNullException(nameof(next));
+        _policySelector = policySelector;
         _defaultPolicy = defaultPolicy ?? throw new ArgumentNullException(nameof(defaultPolicy));
         _nonceGenerator = MustGenerateNonce(_defaultPolicy) ? new() : null;
     }
@@ -43,7 +49,13 @@ internal class SecurityHeadersMiddleware
     public Task Invoke(HttpContext context)
     {
         // Write into the context, so that subsequent requests can "overwrite" it
-        context.Items[HttpContextKey] = _defaultPolicy;
+        var policyToApply = _policySelector(new(context, _defaultPolicy));
+        if (policyToApply is null)
+        {
+            ThrowNull();
+        }
+
+        context.Items[HttpContextKey] = _policySelector(new(context, _defaultPolicy));
         context.Response.OnStarting(OnResponseStarting, context);
         if (_nonceGenerator is not null)
         {
@@ -51,6 +63,11 @@ internal class SecurityHeadersMiddleware
         }
 
         return _next(context);
+    }
+
+    private static void ThrowNull()
+    {
+        throw new InvalidOperationException($"{nameof(SecurityHeaderPolicyBuilder.SetDefaultPolicySelector)} must not return null.");
     }
 
     private static Task OnResponseStarting(object state)

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/SecurityHeadersMiddleware.cs
@@ -22,7 +22,7 @@ internal class SecurityHeadersMiddleware
     private readonly RequestDelegate _next;
     private readonly HeaderPolicyCollection _defaultPolicy;
     private readonly NonceGenerator? _nonceGenerator;
-    private readonly Func<DefaultPolicySelectorContext, HeaderPolicyCollection> _policySelector;
+    private readonly Func<DefaultPolicySelectorContext, IReadOnlyHeaderPolicyCollection> _policySelector;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SecurityHeadersMiddleware"/> class.
@@ -32,7 +32,7 @@ internal class SecurityHeadersMiddleware
     /// <param name="defaultPolicy">A <see cref="HeaderPolicyCollection"/> containing the policy to apply by default.</param>
     public SecurityHeadersMiddleware(
         RequestDelegate next,
-        Func<DefaultPolicySelectorContext, HeaderPolicyCollection> policySelector,
+        Func<DefaultPolicySelectorContext, IReadOnlyHeaderPolicyCollection> policySelector,
         HeaderPolicyCollection defaultPolicy)
     {
         _next = next ?? throw new ArgumentNullException(nameof(next));
@@ -74,7 +74,7 @@ internal class SecurityHeadersMiddleware
     {
         var context = (HttpContext)state;
 
-        if (context.Items[HttpContextKey] is HeaderPolicyCollection policy)
+        if (context.Items[HttpContextKey] is IReadOnlyHeaderPolicyCollection policy)
         {
             var result = CustomHeaderService.EvaluatePolicy(context, policy);
             CustomHeaderService.ApplyResult(context.Response, result);

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.Builder
     {
         public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddFeaturePolicy(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies, System.Action<Microsoft.AspNetCore.Builder.FeaturePolicyBuilder> configure) { }
     }
-    public class HeaderPolicyCollection : System.Collections.Generic.Dictionary<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>
+    public class HeaderPolicyCollection : System.Collections.Generic.Dictionary<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>>, System.Collections.Generic.IReadOnlyDictionary<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>, System.Collections.IEnumerable
     {
         public HeaderPolicyCollection() { }
         public Microsoft.AspNetCore.Builder.HeaderPolicyCollection ApplyDocumentHeadersToAllResponses() { }
@@ -172,6 +172,7 @@ namespace Microsoft.AspNetCore.Builder
     public static class HeaderPolicyCollectionExtensions
     {
         public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddDefaultSecurityHeaders(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies) { }
+        public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection Copy(this NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection policies) { }
     }
     public class PermissionsPolicyBuilder
     {
@@ -473,7 +474,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
     {
         protected DocumentHeaderPolicyBase() { }
         public override void Apply(Microsoft.AspNetCore.Http.HttpContext context, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.CustomHeadersResult result) { }
-        public void Apply(Microsoft.AspNetCore.Http.HttpContext context, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.CustomHeadersResult result, Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies) { }
+        public void Apply(Microsoft.AspNetCore.Http.HttpContext context, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.CustomHeadersResult result, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection policies) { }
     }
     public class ExpectCTHeader : NetEscapades.AspNetCore.SecurityHeaders.Headers.HeaderPolicyBase
     {
@@ -881,11 +882,25 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
         public System.Collections.Generic.ISet<string> RemoveHeaders { get; }
         public System.Collections.Generic.IDictionary<string, string> SetHeaders { get; }
     }
+    public readonly struct DefaultPolicySelectorContext
+    {
+        public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection DefaultPolicy { get; }
+        public Microsoft.AspNetCore.Http.HttpContext HttpContext { get; }
+    }
+    public readonly struct EndpointPolicySelectorContext
+    {
+        public Microsoft.AspNetCore.Http.HttpContext HttpContext { get; }
+        public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection SelectedPolicy { get; }
+        public string SelectedPolicyName { get; }
+    }
+    public interface IReadOnlyHeaderPolicyCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>>, System.Collections.Generic.IReadOnlyDictionary<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>, System.Collections.IEnumerable { }
     public class SecurityHeaderPolicyBuilder
     {
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder AddPolicy(string name, Microsoft.AspNetCore.Builder.HeaderPolicyCollection policyCollection) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder AddPolicy(string name, System.Action<Microsoft.AspNetCore.Builder.HeaderPolicyCollection> configurePolicy) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetDefaultPolicy(Microsoft.AspNetCore.Builder.HeaderPolicyCollection policyCollection) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetDefaultPolicy(System.Action<Microsoft.AspNetCore.Builder.HeaderPolicyCollection> configurePolicy) { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetDefaultPolicySelector(System.Func<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.DefaultPolicySelectorContext, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection> policySelector) { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetEndpointPolicySelector(System.Func<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.EndpointPolicySelectorContext, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection> policySelector) { }
     }
 }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
@@ -317,6 +318,221 @@ public class SecurityHeadersMiddlewareTests
             response.Headers.TryGetValues("X-Frame-Options", out _).Should().BeFalse();
             response.Headers.TryGetValues("Custom-Value", out var h).Should().BeTrue();
             h.Should().ContainSingle("MyValue");
+        }
+    }
+
+    [Fact]
+    public async Task HttpRequest_WithCustomDefaultPolicy_UsesCustomPolicy()
+    {
+        // Arrange
+        var hostBuilder = new WebHostBuilder()
+            .ConfigureServices(s => s.AddSecurityHeaderPolicies()
+                .SetDefaultPolicySelector(ctx =>
+                    ctx.HttpContext.Request.Headers.ContainsKey("AddTo-Default")
+                        ? ctx.DefaultPolicy.Copy().AddCustomHeader("Added-Header", "MyValue")
+                        : ctx.DefaultPolicy))
+            .Configure(app =>
+            {
+                app.UseSecurityHeaders();
+                app.Run(async context =>
+                {
+                    context.Response.ContentType = "text/html";
+                    await context.Response.WriteAsync("Test response");
+                });
+            });
+
+        using (var server = new TestServer(hostBuilder))
+        {
+            // Act
+            // Add header
+            var response = await server.CreateRequest("/")
+                .AddHeader("AddTo-Default", "Something")
+                .SendAsync("PUT");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+
+            (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+            response.Headers.AssertHttpRequestDefaultSecurityHeaders();
+            response.Headers.Should().ContainKey("Added-Header").WhoseValue.Should().Contain("MyValue");
+            
+            
+            // No header
+            response = await server.CreateRequest("/")
+                .SendAsync("PUT");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+
+            (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+            response.Headers.AssertHttpRequestDefaultSecurityHeaders();
+            response.Headers.Should().NotContainKey("Added-Header");
+            
+            
+        }
+    }
+
+    [Fact]
+    public async Task HttpRequest_WithCustomEndpointPolicy_WhenCustomEndpointIsSelected_UsesCustomPolicy()
+    {
+        var policyName = "custom";
+
+        // Arrange
+        var hostBuilder = new WebHostBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddRouting();
+                s.AddSecurityHeaderPolicies()
+                    .AddPolicy(policyName, p => p.AddCustomHeader("Custom-Header", "MyValue"))
+                    .SetEndpointPolicySelector(ctx =>
+                        ctx.SelectedPolicy.Copy().AddCustomHeader("Added-Header", "MyValue"));
+            })
+            .Configure(app =>
+            {
+                app.UseSecurityHeaders();
+                app.UseRouting();
+                app.UseEndpointSecurityHeaders();
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapPut("/", async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    }).WithSecurityHeadersPolicy(policyName);
+                });
+            });
+
+        using (var server = new TestServer(hostBuilder))
+        {
+            // Act
+            // Actual request.
+            var response = await server.CreateRequest("/")
+                .SendAsync("PUT");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+
+            (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+            response.Headers.Should().NotContainKey("X-Frame-Options");
+            response.Headers.Should().ContainKey("Custom-Header").WhoseValue.Should().ContainSingle("MyValue");
+            response.Headers.Should().ContainKey("Added-Header").WhoseValue.Should().ContainSingle("MyValue");
+        }
+    }
+
+    [Fact]
+    public async Task HttpRequest_WithCustomEndpointPolicy_WhenNoEndpointIsSelected_DoesNotUseCustomPolicy()
+    {
+        var policyName = "custom";
+
+        // Arrange
+        var hostBuilder = new WebHostBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddRouting();
+                s.AddSecurityHeaderPolicies()
+                    .AddPolicy(policyName, p => p.AddCustomHeader("Custom-Header", "MyValue"))
+                    .SetEndpointPolicySelector(ctx =>
+                        ctx.SelectedPolicy.Copy().AddCustomHeader("Added-Header", "MyValue"));
+            })
+            .Configure(app =>
+            {
+                app.UseSecurityHeaders();
+                app.UseRouting();
+                app.UseEndpointSecurityHeaders();
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapPut("/", async context =>
+                    {
+                        context.Response.ContentType = "text/html";
+                        await context.Response.WriteAsync("Test response");
+                    });
+                });
+            });
+
+        using (var server = new TestServer(hostBuilder))
+        {
+            // Act
+            // Actual request.
+            var response = await server.CreateRequest("/")
+                .SendAsync("PUT");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+
+            (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+            response.Headers.AssertHttpRequestDefaultSecurityHeaders();
+            response.Headers.Should().NotContainKey("Added-Header");
+        }
+    }
+
+    [Fact]
+    public async Task HttpRequest_WithCustomDefaultPolicy_WhenItReturnsNull_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var hostBuilder = new WebHostBuilder()
+            .ConfigureServices(s => s.AddSecurityHeaderPolicies()
+                .SetDefaultPolicySelector(ctx => null!))
+            .Configure(app =>
+            {
+                app.UseSecurityHeaders();
+                app.Run(async context =>
+                {
+                    context.Response.ContentType = "text/html";
+                    await context.Response.WriteAsync("Test response");
+                });
+            });
+
+        using (var server = new TestServer(hostBuilder))
+        {
+            // Act
+            // Add header
+            var act = async () => await server.CreateRequest("/").SendAsync("PUT");
+            await act.Should().ThrowAsync<InvalidOperationException>();
+        }
+    }
+
+    [Fact]
+    public async Task HttpRequest_WithCustomDefaultPolicy_WhenUsingService_UsesCollection()
+    {
+        // Arrange
+        var hostBuilder = new WebHostBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddScoped<HeaderPolicyCollectionFactory>();
+                s.AddSecurityHeaderPolicies()
+                    .SetDefaultPolicySelector(ctx =>
+                    {
+                        var httpContext = ctx.HttpContext;
+                        var service = httpContext.RequestServices.GetService<HeaderPolicyCollectionFactory>();
+                        var tenantId = httpContext.Request.Headers["Tenant-ID"];
+                        return service.GetPolicy(tenantId);
+                    });
+            })
+            .Configure(app =>
+            {
+                app.UseSecurityHeaders();
+                app.Run(async context =>
+                {
+                    context.Response.ContentType = "text/html";
+                    await context.Response.WriteAsync("Test response");
+                });
+            });
+
+        using (var server = new TestServer(hostBuilder))
+        {
+            // Act
+            // Add header
+            var response = await server.CreateRequest("/")
+                .AddHeader("Tenant-ID", "Default")
+                .SendAsync("PUT");
+            response.EnsureSuccessStatusCode();
+            response.Headers.Should().ContainKey("Custom-Header").WhoseValue.Should().Contain("Default");
+
+            response = await server.CreateRequest("/")
+                .AddHeader("Tenant-ID", "1234")
+                .SendAsync("PUT");
+            response.EnsureSuccessStatusCode();
+            response.Headers.Should().ContainKey("Custom-Header").WhoseValue.Should().Contain("Custom");
         }
     }
 
@@ -2078,5 +2294,14 @@ public class SecurityHeadersMiddlewareTests
             header.Should().NotBeNull();
             header.Should().Be("default=\"https://localhost:5000/default\", endpoint-1=\"http://localhost/endpoint-1\"");
         }
+    }
+
+    private class HeaderPolicyCollectionFactory
+    {
+        private readonly HeaderPolicyCollection _default = new HeaderPolicyCollection().AddCustomHeader("Custom-Header", "Default");
+        private readonly HeaderPolicyCollection _custom = new HeaderPolicyCollection().AddCustomHeader("Custom-Header", "Custom");
+        
+        public HeaderPolicyCollection GetPolicy(string tenantId)
+            => tenantId == "1234" ? _custom : _default;
     }
 }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -503,7 +503,7 @@ public class SecurityHeadersMiddlewareTests
                     .SetDefaultPolicySelector(ctx =>
                     {
                         var httpContext = ctx.HttpContext;
-                        var service = httpContext.RequestServices.GetService<HeaderPolicyCollectionFactory>();
+                        var service = httpContext.RequestServices.GetRequiredService<HeaderPolicyCollectionFactory>();
                         var tenantId = httpContext.Request.Headers["Tenant-ID"];
                         return service.GetPolicy(tenantId);
                     });
@@ -2301,7 +2301,7 @@ public class SecurityHeadersMiddlewareTests
         private readonly HeaderPolicyCollection _default = new HeaderPolicyCollection().AddCustomHeader("Custom-Header", "Default");
         private readonly HeaderPolicyCollection _custom = new HeaderPolicyCollection().AddCustomHeader("Custom-Header", "Custom");
         
-        public HeaderPolicyCollection GetPolicy(string tenantId)
+        public HeaderPolicyCollection GetPolicy(string? tenantId)
             => tenantId == "1234" ? _custom : _default;
     }
 }


### PR DESCRIPTION
Add hooks that allow swapping out the `HeaderPolicyCollection` applied for a request completely

Fixes #64
Fixes #114