### PR TITLE
Allow adding multiple uris to CSP builder `AddFrameAncestors()`

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameAncestorsDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameAncestorsDirectiveBuilder.cs
@@ -107,6 +107,26 @@ public class FrameAncestorsDirectiveBuilder : CspDirectiveBuilderBase
     }
 
     /// <summary>
+    /// Allow resources from the given <paramref name="uris"/>. May be any non-empty value.
+    /// </summary>
+    /// <param name="uris">The URIs to allow.</param>
+    /// <returns>The CSP builder for method chaining</returns>
+    public FrameAncestorsDirectiveBuilder From(IEnumerable<string> uris)
+    {
+        foreach (var uri in uris)
+        {
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                throw new System.ArgumentException("Uri may not be null or empty", nameof(uri));
+            }
+
+            Sources.Add(uri);
+        }
+
+        return this;
+    }
+
+    /// <summary>
     /// Allow resources served over https
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
@@ -356,11 +356,11 @@ public class CspBuilderTests
             .Self()
             .Blob()
             .Data()
-            .From("http://testUrl.com");
+            .From(["http://testUrl.com", "https://testUrl.com"]);
 
         var result = builder.Build();
 
-        result.ConstantValue.Should().Be("frame-ancestors 'self' blob: data: http://testUrl.com");
+        result.ConstantValue.Should().Be("frame-ancestors 'self' blob: data: http://testUrl.com https://testUrl.com");
     }
 
     [Fact]

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -301,6 +301,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public System.Collections.Generic.List<string> Sources { get; }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder Blob() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder Data() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder From(System.Collections.Generic.IEnumerable<string> uris) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder OverHttps() { }


### PR DESCRIPTION
`AddFrameAncestors()` derives from `CspDirectiveBuilderBase` rather than `CspDirectiveBuilder`, so the normal extensions don't apply. This adds the equivalent to `FrameAncestorsDirectiveBuilder` directly

Fixes #178