### PR TITLE
Fix using obsolete version of action

### DIFF
--- a/.github/workflows/BuildAndPack.yml
+++ b/.github/workflows/BuildAndPack.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           GithubToken: ${{ secrets.GITHUB_TOKEN }}
           NuGetToken: ${{ secrets.NUGET_TOKEN }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: artifacts
@@ -82,7 +82,7 @@ jobs:
         env:
           GithubToken: ${{ secrets.GITHUB_TOKEN }}
           NuGetToken: ${{ secrets.NUGET_TOKEN }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: artifacts
@@ -111,7 +111,7 @@ jobs:
         env:
           GithubToken: ${{ secrets.GITHUB_TOKEN }}
           NuGetToken: ${{ secrets.NUGET_TOKEN }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: artifacts

--- a/.github/workflows/BuildAndPack.yml
+++ b/.github/workflows/BuildAndPack.yml
@@ -55,7 +55,7 @@ jobs:
           NuGetToken: ${{ secrets.NUGET_TOKEN }}
       - uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-linux
           path: artifacts
   windows-latest:
     name: windows-latest
@@ -84,7 +84,7 @@ jobs:
           NuGetToken: ${{ secrets.NUGET_TOKEN }}
       - uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-win
           path: artifacts
   macOS-latest:
     name: macos-13 # latest is arm64, and it breaks a bunch of stuff
@@ -113,5 +113,5 @@ jobs:
           NuGetToken: ${{ secrets.NUGET_TOKEN }}
       - uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-macos
           path: artifacts


### PR DESCRIPTION
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v1`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```