### PR TITLE
Update default policies

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
@@ -46,8 +46,33 @@ public static class HeaderPolicyCollectionExtensions
         policies.RemoveServerHeader();
         policies.AddContentSecurityPolicy(builder =>
         {
-            builder.AddObjectSrc().None();
+            builder.AddDefaultSrc().None();
             builder.AddFormAction().Self();
+            builder.AddFrameAncestors().None();
+        });
+        policies.AddPermissionsPolicyWithRecommendedDirectives();
+        return policies;
+    }
+
+    /// <summary>
+    /// Add default headers in accordance with the most secure approach.
+    /// A reduced set of headers is applied compared to <see cref="AddDefaultSecurityHeaders"/>,
+    /// adding only those headers that make sense for APIs returning JSON rather than HTML.
+    /// </summary>
+    /// <remarks>Note that there are non-security headers you should also apply to your responses,
+    /// such as <c>Content-Type</c>, in accordance with
+    /// <see href="https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html#security-headers">OWASP recommendations</see>
+    /// </remarks>
+    /// <param name="policies">The <see cref="HeaderPolicyCollection" /> to add the default security header policies too</param>
+    /// <returns>The <see cref="HeaderPolicyCollection" /> for method chaining</returns>
+    public static HeaderPolicyCollection AddDefaultApiSecurityHeaders(this HeaderPolicyCollection policies)
+    {
+        policies.AddFrameOptionsDeny();
+        policies.AddContentTypeOptionsNoSniff();
+        policies.AddStrictTransportSecurityMaxAge();
+        policies.RemoveServerHeader();
+        policies.AddContentSecurityPolicy(builder =>
+        {
             builder.AddFrameAncestors().None();
         });
         return policies;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeaderExtensions.cs
@@ -10,6 +10,15 @@ namespace Microsoft.AspNetCore.Builder;
 public static class PermissionsPolicyHeaderExtensions
 {
     /// <summary>
+    /// The policy applied by <see cref="AddPermissionsPolicyWithRecommendedDirectives"/>
+    /// </summary>
+    internal const string DefaultSecurePolicy =
+        "accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), display-capture=(), " +
+        "encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), " +
+        "microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), " +
+        "screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()";
+
+    /// <summary>
     /// Add a Permissions-Policy header to all requests
     /// </summary>
     /// <param name="policies">The collection of policies</param>
@@ -18,5 +27,25 @@ public static class PermissionsPolicyHeaderExtensions
     public static HeaderPolicyCollection AddPermissionsPolicy(this HeaderPolicyCollection policies, Action<PermissionsPolicyBuilder> configure)
     {
         return policies.ApplyPolicy(PermissionsPolicyHeader.Build(configure));
+    }
+
+    /// <summary>
+    /// Add a Permissions-Policy with recommended "secure" directives based on
+    /// <see href="https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html#security-headers">OWASP recommendations</see>
+    /// </summary>
+    /// <param name="policies">The collection of policies</param>
+    /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
+    /// <remarks>The OWASP recommended policy includes directives that are either experimental,
+    /// not available by default, or not implemented. For consistency with <see cref="PermissionsPolicyBuilder"/>,
+    /// those directives are not included in the policy.
+    ///
+    /// The policy added is equivalent to <c>accelerometer=(), ambient-light-sensor=(),
+    /// autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(),
+    /// geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(),
+    /// picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(),
+    /// usb=(), web-share=(), xr-spatial-tracking=()</c></remarks>
+    public static HeaderPolicyCollection AddPermissionsPolicyWithRecommendedDirectives(this HeaderPolicyCollection policies)
+    {
+        return policies.ApplyPolicy(new PermissionsPolicyHeader(DefaultSecurePolicy));
     }
 }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HeaderAssertionHelpers.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HeaderAssertionHelpers.cs
@@ -17,7 +17,7 @@ public static class HeaderAssertionHelpers
         header = headers.GetValues("Referrer-Policy").FirstOrDefault()!;
         header.Should().Be("strict-origin-when-cross-origin");
         header = headers.GetValues("Content-Security-Policy").FirstOrDefault()!;
-        header.Should().Be("object-src 'none'; form-action 'self'; frame-ancestors 'none'");
+        header.Should().Be("default-src 'none'; form-action 'self'; frame-ancestors 'none'");
 
         Assert.False(headers.Contains("Server"),
             "Should not contain server header");
@@ -36,7 +36,7 @@ public static class HeaderAssertionHelpers
         header = headers.GetValues("Referrer-Policy").FirstOrDefault()!;
         header.Should().Be("strict-origin-when-cross-origin");
         header = headers.GetValues("Content-Security-Policy").FirstOrDefault()!;
-        header.Should().Be("object-src 'none'; form-action 'self'; frame-ancestors 'none'");
+        header.Should().Be("default-src 'none'; form-action 'self'; frame-ancestors 'none'");
 
         Assert.False(headers.Contains("Server"),
             "Should not contain server header");

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PermissionsPolicyBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PermissionsPolicyBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
+using NetEscapades.AspNetCore.SecurityHeaders.Headers;
 using Xunit;
 
 namespace NetEscapades.AspNetCore.SecurityHeaders.Test;
@@ -180,5 +181,43 @@ public class PermissionsPolicyBuilderTests
         var result = builder.Build();
 
         result.Should().Be("accelerometer=()");
+    }
+
+    [Fact]
+    public void PermissionsPolicy_DefaultSecure_IsEquivalent()
+    {
+        // https://github.com/w3c/webappsec-permissions-policy/blob/f15a4548691ea69a87227c0f67571da2cc0e08c1/features.md?plain=1#L19
+        var builder = new PermissionsPolicyBuilder();
+        builder.AddAccelerometer().None();
+        builder.AddAmbientLightSensor().None();
+        builder.AddAutoplay().None();
+        // builder.AddBattery().None(); // Request: https://issues.chromium.org/issues/40100229
+        builder.AddCamera().None();
+        // builder.AddCrossOriginIsolated().None(); // experimental in chrome 85
+        builder.AddDisplayCapture().None();
+        // builder.AddDocumentDomain().None(); // retired
+        builder.AddEncryptedMedia().None();
+        // builder.AddExecutionWhileNotRendered().None(); // Behind a flag in chrome
+        // builder.AddExecutionWhileOutOfViewport().None();; // Behind a flag in chrome
+        builder.AddFullscreen().None();
+        builder.AddGeolocation().None();
+        builder.AddGyroscope().None();
+        // builder.AddKeyboardMap().None(); // Chrome only https://www.chromestatus.com/feature/5657965899022336
+        builder.AddMagnetometer().None();
+        builder.AddMicrophone().None();
+        builder.AddMidi().None();
+        // builder.AddNavigationOverride().None(); // No implementations
+        builder.AddPayment().None();
+        builder.AddPictureInPicture().None();
+        builder.AddPublickeyCredentialsGet().None();
+        builder.AddScreenWakeLock().None();
+        builder.AddSyncXHR().None();
+        builder.AddUsb().None();
+        builder.AddWebShare().None();
+        builder.AddXrSpatialTracking().None();
+
+        var expected = builder.Build();
+        
+        PermissionsPolicyHeaderExtensions.DefaultSecurePolicy.Should().Be(expected);
     }
 }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -171,6 +171,7 @@ namespace Microsoft.AspNetCore.Builder
     }
     public static class HeaderPolicyCollectionExtensions
     {
+        public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddDefaultApiSecurityHeaders(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies) { }
         public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddDefaultSecurityHeaders(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies) { }
         public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection Copy(this NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection policies) { }
     }
@@ -218,6 +219,7 @@ namespace Microsoft.AspNetCore.Builder
     public static class PermissionsPolicyHeaderExtensions
     {
         public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddPermissionsPolicy(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies, System.Action<Microsoft.AspNetCore.Builder.PermissionsPolicyBuilder> configure) { }
+        public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddPermissionsPolicyWithRecommendedDirectives(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies) { }
     }
     public static class ReferrerPolicyHeaderExtensions
     {


### PR DESCRIPTION
- Adds a "default secure" permissions policy option, based on the suggestion from [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html#security-headers)
  - Only includes directives that are supported by the library (i.e. not experimental/unsupported) directives etc
- Updates the default CSP to add `default-src: none` instead of `obj-src:none` (the latter falls back to `default-src`.
- Add an "API" default secure set of headers, based on the suggestion from [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html#security-headers) for non-HTML endpoints. You can add this by calling `AddDefaultApiSecurityHeaders()`

For the permissions-policy secure default, you can do

```csharp
app.UseSecurityHeaders(p => p.AddPermissionsPolicyWithRecommendedDirectives());
```

This is equivalent to calling
```csharp
app.UseSecurityHeaders(p => p.AddPermissionsPolicy(builder => 
{
    builder.AddAccelerometer().None();
    builder.AddAmbientLightSensor().None();
    builder.AddAutoplay().None();
    builder.AddCamera().None();
    builder.AddDisplayCapture().None();
    builder.AddEncryptedMedia().None();
    builder.AddFullscreen().None();
    builder.AddGeolocation().None();
    builder.AddGyroscope().None();
    builder.AddMagnetometer().None();
    builder.AddMicrophone().None();
    builder.AddMidi().None();
    builder.AddPayment().None();
    builder.AddPictureInPicture().None();
    builder.AddPublickeyCredentialsGet().None();
    builder.AddScreenWakeLock().None();
    builder.AddSyncXHR().None();
    builder.AddUsb().None();
    builder.AddWebShare().None();
    builder.AddXrSpatialTracking().None();
}));
```

Related to #133