### PR TITLE
Update defaults again

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollectionExtensions.cs
@@ -46,11 +46,11 @@ public static class HeaderPolicyCollectionExtensions
         policies.RemoveServerHeader();
         policies.AddContentSecurityPolicy(builder =>
         {
-            builder.AddDefaultSrc().None();
+            builder.AddObjectSrc().None();
             builder.AddFormAction().Self();
             builder.AddFrameAncestors().None();
         });
-        policies.AddPermissionsPolicyWithRecommendedDirectives();
+        policies.AddCrossOriginOpenerPolicy(x => x.SameOrigin());
         return policies;
     }
 
@@ -73,8 +73,13 @@ public static class HeaderPolicyCollectionExtensions
         policies.RemoveServerHeader();
         policies.AddContentSecurityPolicy(builder =>
         {
+            builder.AddDefaultSrc().None();
             builder.AddFrameAncestors().None();
         });
+
+        // The following are generally not applicable, but still worth applying for safety
+        policies.AddReferrerPolicyNoReferrer();
+        policies.AddPermissionsPolicyWithDefaultSecureDirectives();
         return policies;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyBuilder.cs
@@ -381,6 +381,81 @@ public class PermissionsPolicyBuilder
     /// <returns>A configured <see cref="CustomPermissionsPolicyDirectiveBuilder"/></returns>
     public CustomPermissionsPolicyDirective AddCustomFeature(string directive, string value) => AddDirective(new CustomPermissionsPolicyDirective(directive, value));
 
+    /// <summary>
+    /// Add a Permissions-Policy with recommended "secure" directives based on
+    /// <see href="https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html#security-headers">OWASP recommendations</see>.
+    /// Note that this disables many features. If you need to enable some features, add additional directives, to override
+    /// the required policy.
+    /// </summary>
+    /// <returns>The <see cref="PermissionsPolicyBuilder"/> for method chaining</returns>
+    /// <remarks>The OWASP recommended policy includes directives that are either experimental,
+    /// not available by default, or not implemented. For consistency,
+    /// those directives are not included in the policy.
+    ///
+    /// The policy added is equivalent to
+    /// <code>
+    /// AddAccelerometer().None();
+    /// AddAmbientLightSensor().None();
+    /// AddAutoplay().None();
+    /// AddCamera().None();
+    /// AddDisplayCapture().None();
+    /// AddEncryptedMedia().None();
+    /// AddFullscreen().None();
+    /// AddGeolocation().None();
+    /// AddGyroscope().None();
+    /// AddMagnetometer().None();
+    /// AddMicrophone().None();
+    /// AddMidi().None();
+    /// AddPayment().None();
+    /// AddPictureInPicture().None();
+    /// AddPublickeyCredentialsGet().None();
+    /// AddScreenWakeLock().None();
+    /// AddSyncXHR().None();
+    /// AddUsb().None();
+    /// AddWebShare().None();
+    /// AddXrSpatialTracking().None();
+    /// </code>
+    /// </remarks>
+    public PermissionsPolicyBuilder AddDefaultSecureDirectives()
+    {
+        // https://github.com/w3c/webappsec-permissions-policy/blob/f15a4548691ea69a87227c0f67571da2cc0e08c1/features.md?plain=1#L19
+        AddAccelerometer().None();
+        AddAmbientLightSensor().None();
+        AddAutoplay().None();
+
+        // AddBattery().None(); // Request: https://issues.chromium.org/issues/40100229
+        AddCamera().None();
+
+        // AddCrossOriginIsolated().None(); // experimental in chrome 85
+        AddDisplayCapture().None();
+
+        // AddDocumentDomain().None(); // retired
+        AddEncryptedMedia().None();
+
+        // AddExecutionWhileNotRendered().None(); // Behind a flag in chrome
+
+        // AddExecutionWhileOutOfViewport().None();; // Behind a flag in chrome
+        AddFullscreen().None();
+        AddGeolocation().None();
+        AddGyroscope().None();
+
+        // AddKeyboardMap().None(); // Chrome only https://www.chromestatus.com/feature/5657965899022336
+        AddMagnetometer().None();
+        AddMicrophone().None();
+        AddMidi().None();
+
+        // AddNavigationOverride().None(); // No implementations
+        AddPayment().None();
+        AddPictureInPicture().None();
+        AddPublickeyCredentialsGet().None();
+        AddScreenWakeLock().None();
+        AddSyncXHR().None();
+        AddUsb().None();
+        AddWebShare().None();
+        AddXrSpatialTracking().None();
+        return this;
+    }
+
     private T AddDirective<T>(T directive) where T : PermissionsPolicyDirectiveBuilderBase
     {
         _directives[directive.Directive] = directive;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeaderExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Builder;
 public static class PermissionsPolicyHeaderExtensions
 {
     /// <summary>
-    /// The policy applied by <see cref="AddPermissionsPolicyWithRecommendedDirectives"/>
+    /// The policy applied by <see cref="AddPermissionsPolicyWithDefaultSecureDirectives"/>
     /// </summary>
     internal const string DefaultSecurePolicy =
         "accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), display-capture=(), " +
@@ -31,7 +31,9 @@ public static class PermissionsPolicyHeaderExtensions
 
     /// <summary>
     /// Add a Permissions-Policy with recommended "secure" directives based on
-    /// <see href="https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html#security-headers">OWASP recommendations</see>
+    /// <see href="https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html#security-headers">OWASP recommendations</see>.
+    /// Note that this disables many features. If you need to enable some features, consider calling <see cref="AddPermissionsPolicy"/>
+    /// and <see cref="PermissionsPolicyBuilder.AddDefaultSecureDirectives"/>, and overriding one or more policies.
     /// </summary>
     /// <param name="policies">The collection of policies</param>
     /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
@@ -44,7 +46,7 @@ public static class PermissionsPolicyHeaderExtensions
     /// geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(),
     /// picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(),
     /// usb=(), web-share=(), xr-spatial-tracking=()</c></remarks>
-    public static HeaderPolicyCollection AddPermissionsPolicyWithRecommendedDirectives(this HeaderPolicyCollection policies)
+    public static HeaderPolicyCollection AddPermissionsPolicyWithDefaultSecureDirectives(this HeaderPolicyCollection policies)
     {
         return policies.ApplyPolicy(new PermissionsPolicyHeader(DefaultSecurePolicy));
     }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HeaderAssertionHelpers.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/HeaderAssertionHelpers.cs
@@ -17,7 +17,9 @@ public static class HeaderAssertionHelpers
         header = headers.GetValues("Referrer-Policy").FirstOrDefault()!;
         header.Should().Be("strict-origin-when-cross-origin");
         header = headers.GetValues("Content-Security-Policy").FirstOrDefault()!;
-        header.Should().Be("default-src 'none'; form-action 'self'; frame-ancestors 'none'");
+        header.Should().Be("object-src 'none'; form-action 'self'; frame-ancestors 'none'");
+        headers.Should().ContainKey("Cross-Origin-Opener-Policy")
+            .WhoseValue.Should().ContainSingle("same-origin");
 
         Assert.False(headers.Contains("Server"),
             "Should not contain server header");
@@ -36,7 +38,7 @@ public static class HeaderAssertionHelpers
         header = headers.GetValues("Referrer-Policy").FirstOrDefault()!;
         header.Should().Be("strict-origin-when-cross-origin");
         header = headers.GetValues("Content-Security-Policy").FirstOrDefault()!;
-        header.Should().Be("default-src 'none'; form-action 'self'; frame-ancestors 'none'");
+        header.Should().Be("object-src 'none'; form-action 'self'; frame-ancestors 'none'");
 
         Assert.False(headers.Contains("Server"),
             "Should not contain server header");

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PermissionsPolicyBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PermissionsPolicyBuilderTests.cs
@@ -186,35 +186,8 @@ public class PermissionsPolicyBuilderTests
     [Fact]
     public void PermissionsPolicy_DefaultSecure_IsEquivalent()
     {
-        // https://github.com/w3c/webappsec-permissions-policy/blob/f15a4548691ea69a87227c0f67571da2cc0e08c1/features.md?plain=1#L19
-        var builder = new PermissionsPolicyBuilder();
-        builder.AddAccelerometer().None();
-        builder.AddAmbientLightSensor().None();
-        builder.AddAutoplay().None();
-        // builder.AddBattery().None(); // Request: https://issues.chromium.org/issues/40100229
-        builder.AddCamera().None();
-        // builder.AddCrossOriginIsolated().None(); // experimental in chrome 85
-        builder.AddDisplayCapture().None();
-        // builder.AddDocumentDomain().None(); // retired
-        builder.AddEncryptedMedia().None();
-        // builder.AddExecutionWhileNotRendered().None(); // Behind a flag in chrome
-        // builder.AddExecutionWhileOutOfViewport().None();; // Behind a flag in chrome
-        builder.AddFullscreen().None();
-        builder.AddGeolocation().None();
-        builder.AddGyroscope().None();
-        // builder.AddKeyboardMap().None(); // Chrome only https://www.chromestatus.com/feature/5657965899022336
-        builder.AddMagnetometer().None();
-        builder.AddMicrophone().None();
-        builder.AddMidi().None();
-        // builder.AddNavigationOverride().None(); // No implementations
-        builder.AddPayment().None();
-        builder.AddPictureInPicture().None();
-        builder.AddPublickeyCredentialsGet().None();
-        builder.AddScreenWakeLock().None();
-        builder.AddSyncXHR().None();
-        builder.AddUsb().None();
-        builder.AddWebShare().None();
-        builder.AddXrSpatialTracking().None();
+        var builder = new PermissionsPolicyBuilder()
+            .AddDefaultSecureDirectives();
 
         var expected = builder.Build();
         

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -186,6 +186,7 @@ namespace Microsoft.AspNetCore.Builder
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy.CameraPermissionsPolicyDirectiveBuilder AddCamera() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy.CustomPermissionsPolicyDirectiveBuilder AddCustomFeature(string directive) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy.CustomPermissionsPolicyDirective AddCustomFeature(string directive, string value) { }
+        public Microsoft.AspNetCore.Builder.PermissionsPolicyBuilder AddDefaultSecureDirectives() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy.DisplayCapturePermissionsPolicyDirectiveBuilder AddDisplayCapture() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy.EncryptedMediaPermissionsPolicyDirectiveBuilder AddEncryptedMedia() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.PermissionsPolicy.FederatedLearningOfCohortsCalculationPermissionsPolicyDirectiveBuilder AddFederatedLearningOfCohortsCalculation() { }
@@ -219,7 +220,7 @@ namespace Microsoft.AspNetCore.Builder
     public static class PermissionsPolicyHeaderExtensions
     {
         public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddPermissionsPolicy(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies, System.Action<Microsoft.AspNetCore.Builder.PermissionsPolicyBuilder> configure) { }
-        public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddPermissionsPolicyWithRecommendedDirectives(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies) { }
+        public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddPermissionsPolicyWithDefaultSecureDirectives(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies) { }
     }
     public static class ReferrerPolicyHeaderExtensions
     {


### PR DESCRIPTION
Partial revert of #183, as it was a bit over zealous

- Update defaults API
  - CSP for changed back to `object-src: none`, not `default-src: none`. Less secure, but more broadly applicable, `default-src: none` is going to work for ~0% of sites 😅
  - Added `cross-origin-opener-policy: same-origin` as default
  - Remove default permissions policy - it's easy to add it now
- Change defaults for API endpoint
  - Add `default-src: none` to CSP
  - Add referrer: no-referrer
  - Add permission policy with default secure