### PR TITLE
Mark FeaturePolicy as obsolete

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/FeaturePolicyHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/FeaturePolicyHeader.cs
@@ -7,6 +7,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers;
 /// <summary>
 /// The header value to use for Feature-Policy.
 /// </summary>
+[Obsolete("The Feature-Policy header has been deprecated. Use Permissions-Policy instead.")]
 public class FeaturePolicyHeader : HeaderPolicyBase
 {
     private readonly string _value;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/FeaturePolicyHeaderextensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/FeaturePolicyHeaderextensions.cs
@@ -15,6 +15,7 @@ public static class FeaturePolicyHeaderExtensions
     /// <param name="policies">The collection of policies</param>
     /// <param name="configure">Configure the Feature-Policy</param>
     /// <returns>The <see cref="HeaderPolicyCollection"/> for method chaining</returns>
+    [Obsolete("The Feature-Policy header has been deprecated. Use Permissions-Policy instead by calling AddPermissionsPolicy()")]
     public static HeaderPolicyCollection AddFeaturePolicy(this HeaderPolicyCollection policies, Action<FeaturePolicyBuilder> configure)
     {
         return policies.ApplyPolicy(FeaturePolicyHeader.Build(configure));

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -161,6 +161,8 @@ namespace Microsoft.AspNetCore.Builder
     }
     public static class FeaturePolicyHeaderExtensions
     {
+        [System.Obsolete("The Feature-Policy header has been deprecated. Use Permissions-Policy instead by " +
+            "calling AddPermissionsPolicy()")]
         public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddFeaturePolicy(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies, System.Action<Microsoft.AspNetCore.Builder.FeaturePolicyBuilder> configure) { }
     }
     public class HeaderPolicyCollection : System.Collections.Generic.Dictionary<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>>, System.Collections.Generic.IReadOnlyDictionary<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>, System.Collections.IEnumerable
@@ -502,6 +504,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
         protected override void EvaluateHttpsRequest(Microsoft.AspNetCore.Http.HttpContext context, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.CustomHeadersResult result) { }
         protected override string GetValue(Microsoft.AspNetCore.Http.HttpContext context) { }
     }
+    [System.Obsolete("The Feature-Policy header has been deprecated. Use Permissions-Policy instead.")]
     public class FeaturePolicyHeader : NetEscapades.AspNetCore.SecurityHeaders.Headers.HeaderPolicyBase
     {
         public FeaturePolicyHeader(string value) { }


### PR DESCRIPTION
Feature-Policy is deprecated in favour of Permissions-Policy, so marking it obsolete