### PR TITLE
Mark ExpectCTHeader as obsolete

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ExpectCTHeader.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ExpectCTHeader.cs
@@ -8,8 +8,17 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers;
 /// <summary>
 /// The header value to use for Expect-CT
 /// </summary>
+[Obsolete(ObsoleteHeader)]
 public class ExpectCTHeader : HeaderPolicyBase
 {
+    /// <summary>
+    /// Obsolete header description
+    /// </summary>
+    internal const string ObsoleteHeader =
+        "This feature is no longer recommended. Only Chromium-based browsers implemented Expect-CT, " +
+        "and Chromium has deprecated the header from version 107, because Chromium now enforces CT " +
+        "by default. For more details see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT.";
+
     private readonly string _value;
     private readonly IReadOnlyList<string> _excludedHosts;
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ExpectCTHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ExpectCTHeaderExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using NetEscapades.AspNetCore.SecurityHeaders.Headers;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -5,6 +6,7 @@ namespace Microsoft.AspNetCore.Builder;
 /// <summary>
 /// Extension methods for adding a <see cref="ExpectCTHeader" /> to a <see cref="HeaderPolicyCollection" />
 /// </summary>
+[Obsolete(ExpectCTHeader.ObsoleteHeader)]
 public static class ExpectCTHeaderExtensions
 {
     private static readonly string[] _excludedHosts =

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -128,6 +128,7 @@ namespace Microsoft.AspNetCore.Builder
         public static TBuilder WithSecurityHeadersPolicy<TBuilder>(this TBuilder builder, string policyName)
             where TBuilder : Microsoft.AspNetCore.Builder.IEndpointConventionBuilder { }
     }
+    [System.Obsolete(@"This feature is no longer recommended. Only Chromium-based browsers implemented Expect-CT, and Chromium has deprecated the header from version 107, because Chromium now enforces CT by default. For more details see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT.")]
     public static class ExpectCTHeaderExtensions
     {
         public static Microsoft.AspNetCore.Builder.HeaderPolicyCollection AddExpectCT(this Microsoft.AspNetCore.Builder.HeaderPolicyCollection policies, int maxAgeInSeconds, string reportUri, bool enforce, params string[] excludedHosts) { }
@@ -499,6 +500,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers
         public override string Header { get; }
         protected override string GetValue(Microsoft.AspNetCore.Http.HttpContext context) { }
     }
+    [System.Obsolete(@"This feature is no longer recommended. Only Chromium-based browsers implemented Expect-CT, and Chromium has deprecated the header from version 107, because Chromium now enforces CT by default. For more details see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT.")]
     public class ExpectCTHeader : NetEscapades.AspNetCore.SecurityHeaders.Headers.HeaderPolicyBase
     {
         public ExpectCTHeader(string value, System.Collections.Generic.IReadOnlyList<string> excludedHosts) { }


### PR DESCRIPTION
Expect-CT is no longer recommended according to MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT