### PR TITLE
Make nonce generation lazy

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HttpContextExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HttpContextExtensions.cs
@@ -18,22 +18,13 @@ public static class HttpContextExtensions
     /// <returns>The nonce for the request, as a string</returns>
     public static string GetNonce(this HttpContext context)
     {
-        return context.Items[Constants.DefaultNonceKey] as string ?? string.Empty;
-    }
-
-    /// <summary>
-    /// Fetch the nonce (number used once) for the request
-    /// </summary>
-    /// <param name="context">The <see cref="HttpContext"/> for the request</param>
-    /// <param name="nonce">The nonce to set for the request</param>
-    internal static void SetNonce(this HttpContext context, string nonce)
-    {
-        if (string.IsNullOrEmpty(nonce))
+        if (context.Items[Constants.DefaultNonceKey] is not string nonce)
         {
-            throw new ArgumentException("Value cannot be null or empty.", nameof(nonce));
+            nonce = NonceGenerator.CreateNonce();
+            context.Items[Constants.DefaultNonceKey] = nonce;
         }
 
-        context.Items[Constants.DefaultNonceKey] = nonce;
+        return nonce;
     }
 
     /// <summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/NonceGenerator.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/NonceGenerator.cs
@@ -14,7 +14,7 @@ internal static class NonceGenerator
     /// <returns>The nonce as a string</returns>
     public static string CreateNonce()
     {
-        var bytes = new byte[Constants.DefaultBytesInNonce];
+        Span<byte> bytes = stackalloc byte[Constants.DefaultBytesInNonce];
         RandomNumberGenerator.Fill(bytes);
         return Convert.ToBase64String(bytes);
     }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/NonceGenerator.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/NonceGenerator.cs
@@ -6,31 +6,16 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
 /// <summary>
 /// Generates nonce values using <see cref="RandomNumberGenerator"/>
 /// </summary>
-internal class NonceGenerator : IDisposable
+internal static class NonceGenerator
 {
-    // RandomNumberGenerator.Create is preferred over calling the constructor of the derived class RNGCryptoServiceProvider.
-    // https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator?view=netframework-4.7.2#remarks
-    private readonly RandomNumberGenerator _random = RandomNumberGenerator.Create();
-
     /// <summary>
     /// Generate a nonce
     /// </summary>
-    /// <param name="nonceBytes">The number of bytes used to generate a nonce</param>
     /// <returns>The nonce as a string</returns>
-    public string GetNonce(int nonceBytes)
+    public static string CreateNonce()
     {
-        // Probably no point in using ArrayPool as these are such small arrays.
-        // Adds a slight GC pressure but https://adamsitnik.com/Array-Pool/ suggests
-        // it's probably OK
-        var bytes = new byte[nonceBytes];
-        _random.GetBytes(bytes);
-
+        var bytes = new byte[Constants.DefaultBytesInNonce];
+        RandomNumberGenerator.Fill(bytes);
         return Convert.ToBase64String(bytes);
-    }
-
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        _random.Dispose();
     }
 }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/NonceTagHelperTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/NonceTagHelperTests.cs
@@ -63,7 +63,7 @@ public class NonceTagHelperTests
         var id = Guid.NewGuid().ToString();
         var tagName = "script";
         var tagHelperContext = GetTagHelperContext(id, tagName);
-        string? nonceValue = null;
+        var nonceValue = string.Empty;
         var nonceTagHelper = new NonceTagHelper
         {
             AddNonce = true,
@@ -90,13 +90,10 @@ public class NonceTagHelperTests
         Assert.Equal("Something Else", output.Content.GetContent());
     }
 
-    private static ViewContext GetViewContext(string? nonce)
+    private static ViewContext GetViewContext(string nonce)
     {
         var actionContext = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
-        if (!string.IsNullOrEmpty(nonce))
-        {
-            actionContext.HttpContext.SetNonce(nonce!);
-        }
+        actionContext.HttpContext.Items[Infrastructure.Constants.DefaultNonceKey] = nonce;
 
         actionContext.HttpContext.RequestServices = new ServiceCollection()
             .AddTransient(_ => Mock.Of<ILogger<NonceTagHelper>>())

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
@@ -575,7 +575,7 @@ public class CspBuilderTests
 
         var httpContext = new DefaultHttpContext();
         var nonce = "ABC123";
-        httpContext.SetNonce(nonce);
+        httpContext.Items[Infrastructure.Constants.DefaultNonceKey] = nonce;
 
         var csp = result.Builder(httpContext);
 
@@ -592,7 +592,7 @@ public class CspBuilderTests
 
         var httpContext = new DefaultHttpContext();
         var nonce = "ABC123";
-        httpContext.SetNonce(nonce);
+        httpContext.Items[Infrastructure.Constants.DefaultNonceKey] = nonce;
 
         var csp = result.Builder(httpContext);
 
@@ -610,7 +610,7 @@ public class CspBuilderTests
 
         var httpContext = new DefaultHttpContext();
         var nonce = "ABC123";
-        httpContext.SetNonce(nonce);
+        httpContext.Items[Infrastructure.Constants.DefaultNonceKey] = nonce;
 
         var csp = result.Builder(httpContext);
 


### PR DESCRIPTION
With the changes to having named policies, it's no longer obvious ahead of time whether nonce generation will be required, so we need to always generate it.

To avoid the overhead of creating the nonce in cases where we _don't_ need it, switch to creating it lazily with the call to `HttpContext.GetNonce()`. The code in there isn't thread safe, but then HttpContext isn't thread safe in general so it probably doesn't matter.

Note that means you _must_ use the `GetNonce()` extension to retrieve the nonce, you can't just grab it out directly. While technically not a breaking change it oculd be if people are relying on the implementation