### PR TITLE
Allow accessing an `IServiceProvider` when configuring a `SecurityHeaderPolicyBuilder`

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/ServiceCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/ServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ public static class ServiceCollectionExtensions
     /// Creates a builder for configuring security header policies.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    /// <returns>The <see cref="SecurityHeaderPolicyBuilder"/> so that header policies can be configured.</returns>
     public static SecurityHeaderPolicyBuilder AddSecurityHeaderPolicies(this IServiceCollection services)
     {
         if (services == null)
@@ -24,5 +24,36 @@ public static class ServiceCollectionExtensions
         var options = new CustomHeaderOptions();
         services.AddSingleton(options);
         return new SecurityHeaderPolicyBuilder(options);
+    }
+
+    /// <summary>
+    /// Creates a builder for configuring security header policies.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+    /// <param name="configure">A configuration method that provides access to an <see cref="IServiceProvider"/>
+    /// to configure your header policies</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddSecurityHeaderPolicies(
+        this IServiceCollection services,
+        Action<SecurityHeaderPolicyBuilder, IServiceProvider> configure)
+    {
+        if (services == null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (configure == null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
+        var options = new CustomHeaderOptions();
+        services.AddSingleton<CustomHeaderOptions>(provider =>
+        {
+            configure(new SecurityHeaderPolicyBuilder(options), provider);
+            return options;
+        });
+
+        return services;
     }
 }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -294,6 +294,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class ServiceCollectionExtensions
     {
         public static NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder AddSecurityHeaderPolicies(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddSecurityHeaderPolicies(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder, System.IServiceProvider> configure) { }
     }
 }
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy


### PR DESCRIPTION
Fixes #199 