### PR TITLE
Remove ambient-light-sensor=() Fix browser warning: Error with Permissions-Policy header: Unrecognized feature: 'ambient-light-sensor'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ As described in the [OWASP guidance](https://cheatsheetseries.owasp.org/cheatshe
 * `X-Frame-Options: Deny`
 * `Content-Security-Policy: default-src: none; frame-ancestors 'none'`
 * `Referrer-Policy: no-referrer`
-* `Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()`
+* `Permissions-Policy: accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()`
 
 Apply it in the same way to your header policy collection:
 
@@ -449,10 +449,6 @@ public void Configure(IApplicationBuilder app)
                 .Self()
                 .For("http://testUrl.com");
 
-            builder.AddAmbientLightSensor() // ambient-light-sensor 'self' http://testUrl.com
-                .Self()
-                .For("http://testUrl.com");
-
             builder.AddAutoplay() // autoplay 'self'
                 .Self();
 
@@ -523,7 +519,7 @@ var policyCollection = new HeaderPolicyCollection()
 This applies a "secure" policy based on the [suggested by OWASP for APIs](https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html#security-headers):
 
 ```HTTP
-Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()
+Permissions-Policy: accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()
 ```
 
 Alternatively, if you want to relax some of these directives, you can use the builder version:

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyBuilder.cs
@@ -420,7 +420,6 @@ public class PermissionsPolicyBuilder
     {
         // https://github.com/w3c/webappsec-permissions-policy/blob/f15a4548691ea69a87227c0f67571da2cc0e08c1/features.md?plain=1#L19
         AddAccelerometer().None();
-        AddAmbientLightSensor().None();
         AddAutoplay().None();
 
         // AddBattery().None(); // Request: https://issues.chromium.org/issues/40100229

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeaderExtensions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicyHeaderExtensions.cs
@@ -13,7 +13,7 @@ public static class PermissionsPolicyHeaderExtensions
     /// The policy applied by <see cref="AddPermissionsPolicyWithDefaultSecureDirectives"/>
     /// </summary>
     internal const string DefaultSecurePolicy =
-        "accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), display-capture=(), " +
+        "accelerometer=(), autoplay=(), camera=(), display-capture=(), " +
         "encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), " +
         "microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), " +
         "screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()";
@@ -41,7 +41,7 @@ public static class PermissionsPolicyHeaderExtensions
     /// not available by default, or not implemented. For consistency with <see cref="PermissionsPolicyBuilder"/>,
     /// those directives are not included in the policy.
     ///
-    /// The policy added is equivalent to <c>accelerometer=(), ambient-light-sensor=(),
+    /// The policy added is equivalent to <c>accelerometer=(),
     /// autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(),
     /// geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(),
     /// picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(),


### PR DESCRIPTION
Fix browser warning for default  PermissionPolicy

Error with Permissions-Policy header: Unrecognized feature: 'ambient-light-sensor'.