### PR TITLE
Added net9.0 to target frameworks so package works with .NET 9 projects.

### DIFF
--- a/.github/workflows/BuildAndPack.yml
+++ b/.github/workflows/BuildAndPack.yml
@@ -42,6 +42,7 @@ jobs:
             3.1.x
             6.0.x
             8.0.401
+            9.0.100
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
@@ -72,6 +73,7 @@ jobs:
             3.1.x
             6.0.x
             8.0.401
+            9.0.100
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
@@ -102,6 +104,7 @@ jobs:
             3.1.x
             6.0.x
             8.0.401
+            9.0.100
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,25 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "properties": {
-    "Configuration": {
-      "type": "string",
-      "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
-      "enum": [
-        "Debug",
-        "Release"
-      ]
-    },
-    "GithubToken": {
-      "type": "string"
-    },
-    "NuGetToken": {
-      "type": "string"
-    },
-    "Solution": {
-      "type": "string",
-      "description": "Path to a solution file that is automatically loaded"
-    }
-  },
   "definitions": {
     "Host": {
       "type": "string",
@@ -120,5 +100,31 @@
       }
     }
   },
-  "$ref": "#/definitions/NukeBuild"
+  "allOf": [
+    {
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "GithubToken": {
+          "type": "string"
+        },
+        "NuGetToken": {
+          "type": "string"
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.0.0-preview.3]
+
+Fixes:
+
+* Added net9.0 to target frameworks so package works with .NET 9 projects.
+
+
 ## [v1.0.0-preview.2]
 
 Features:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PM> Install-Package NetEscapades.AspNetCore.SecurityHeaders
 Or using the `dotnet` CLI
 
 ```bash
-dotnet add package NetEscapades.AspNetCore.SecurityHeaders --version 1.0.0-preview.2
+dotnet add package NetEscapades.AspNetCore.SecurityHeaders --version 1.0.0-preview.3
 ```
 
 ## Usage
@@ -33,7 +33,7 @@ When you install the package, it should be added to your `.csproj`. Alternativel
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.0.0-preview.2" />
+    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.0.0-preview.3" />
   </ItemGroup>
   
 </Project>
@@ -554,7 +554,7 @@ To use a nonce or an auto-generated hash with your ASP.NET Core application, use
 For example:
 
 ```bash
-dotnet package add Install-Package NetEscapades.AspNetCore.SecurityHeaders.TagHelpers --version 1.0.0-preview.2
+dotnet package add Install-Package NetEscapades.AspNetCore.SecurityHeaders.TagHelpers --version 1.0.0-preview.3
 ```
 
 This adds the package to your _.csproj_ file:
@@ -567,8 +567,8 @@ This adds the package to your _.csproj_ file:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.0.0-preview.2" />
-    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="1.0.0-preview.2" />
+    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.0.0-preview.3" />
+    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="1.0.0-preview.3" />
   </ItemGroup>
   
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="8.1.0" />
+    <PackageReference Include="Nuke.Common" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "9.0.100",
     "rollForward": "minor",
     "allowPrerelease": true
   }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/CryptographyAlgorithms.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/CryptographyAlgorithms.cs
@@ -7,7 +7,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.TagHelpers;
 /// <summary>
 /// Helpers for creating hashing algorithms
 /// </summary>
-internal class CryptographyAlgorithms
+internal static class CryptographyAlgorithms
 {
     /// <summary>
     /// Create an instance of the required hashing algorithm
@@ -45,7 +45,9 @@ internal class CryptographyAlgorithms
             // SHA256.Create is documented to throw this exception on FIPS compliant machines.
             // See: https://msdn.microsoft.com/en-us/library/z08hz7ad%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
             // Fallback to a FIPS compliant SHA256 algorithm.
+            #pragma warning disable SYSLIB0021 // Type or member is obsolete
             return new SHA256CryptoServiceProvider();
+            #pragma warning restore SYSLIB0021 // Type or member is obsolete
         }
     }
 
@@ -65,7 +67,9 @@ internal class CryptographyAlgorithms
             // SHA384.Create is documented to throw this exception on FIPS compliant machines.
             // See: https://msdn.microsoft.com/en-us/library/z08hz7ad%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
             // Fallback to a FIPS compliant SHA384 algorithm.
+            #pragma warning disable SYSLIB0021 // Type or member is obsolete
             return new SHA384CryptoServiceProvider();
+            #pragma warning restore SYSLIB0021 // Type or member is obsolete
         }
     }
 
@@ -85,7 +89,9 @@ internal class CryptographyAlgorithms
             // SHA512.Create is documented to throw this exception on FIPS compliant machines.
             // See: https://msdn.microsoft.com/en-us/library/z08hz7ad%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
             // Fallback to a FIPS compliant SHA512 algorithm.
+            #pragma warning disable SYSLIB0021 // Type or member is obsolete
             return new SHA512CryptoServiceProvider();
+            #pragma warning restore SYSLIB0021 // Type or member is obsolete
         }
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.csproj
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>Tag Helpers for the ASP.NET Core Security Headers middleware for adding Nonces for use with SecurityHeadersMiddleware</Description>
-        <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net9.0;</TargetFrameworks>
         <NoWarn>$(NoWarn)</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/NetEscapades.AspNetCore.SecurityHeaders.csproj
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/NetEscapades.AspNetCore.SecurityHeaders.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Middleware for ASP.NET Core to automatically add security headers to requests.</Description>
-    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net9.0;</TargetFrameworks>
     <NoWarn>$(NoWarn)</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test.csproj
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0;net9.0;</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <RunSettingsFilePath>X:\github\NetEscapades.AspNetCore.SecurityHeaders\test\NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test\bin\Debug\netcoreapp3.1\fine-code-coverage\coverage-tool-output\NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test %28netcoreapp3.1%29-fcc-mscodecoverage-generated.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/NetEscapades.AspNetCore.SecurityHeaders.Test.csproj
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/NetEscapades.AspNetCore.SecurityHeaders.Test.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <Authors>Andrew Lock</Authors>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0;net9.0</TargetFrameworks>
     <AssemblyName>NetEscapades.AspNetCore.SecurityHeaders.Test</AssemblyName>
     <PackageId>NetEscapades.AspNetCore.SecurityHeaders.Test</PackageId>
     <Nullable>enable</Nullable>
+    <RunSettingsFilePath>X:\github\NetEscapades.AspNetCore.SecurityHeaders\test\NetEscapades.AspNetCore.SecurityHeaders.Test\bin\Debug\netcoreapp3.1\fine-code-coverage\coverage-tool-output\NetEscapades.AspNetCore.SecurityHeaders.Test %28netcoreapp3.1%29-fcc-mscodecoverage-generated.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
     <PackageReference Include="Verify.Xunit" Version="18.4.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
@@ -25,15 +26,19 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.32" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.36" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/RazorWebSite/RazorWebSite.csproj
+++ b/test/RazorWebSite/RazorWebSite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/SecurityHeadersMiddlewareWebSite/SecurityHeadersMiddlewareWebSite.csproj
+++ b/test/SecurityHeadersMiddlewareWebSite/SecurityHeadersMiddlewareWebSite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0;net9.0</TargetFrameworks>
     <AssemblyName>SecurityHeadersMiddlewareWebSite</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>SecurityHeadersMiddlewareWebSite</PackageId>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.2</VersionSuffix>
+    <VersionSuffix>preview.3</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
When using this package with a .NET 9 project you get the error "Package NetEscapades.AspNetCore.SecurityHeaders 1.0.0-preview.2 is not compatible with net90 (.NETFramework,Version=v9.0). Package NetEscapades.AspNetCore.SecurityHeaders 1.0.0-preview.2 supports: netcoreapp3.1 (.NETCoreApp,Version=v3.1)"