### PR TITLE
Don't test .NET Core 3.1 on Linux

### DIFF
--- a/.github/workflows/BuildAndPack.yml
+++ b/.github/workflows/BuildAndPack.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           GithubToken: ${{ secrets.GITHUB_TOKEN }}
           NuGetToken: ${{ secrets.NUGET_TOKEN }}
+          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: "true"
       - uses: actions/upload-artifact@v4
         with:
           name: artifacts-linux

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test.csproj
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test/NetEscapades.AspNetCore.SecurityHeaders.TagHelpers.Test.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <!-- .NET Core 3.1 won't run easily in github actions (due to missing libssl) so limit it to Windows-->
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;$(TargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/NetEscapades.AspNetCore.SecurityHeaders.Test.csproj
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/NetEscapades.AspNetCore.SecurityHeaders.Test.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <Authors>Andrew Lock</Authors>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <!-- .NET Core 3.1 won't run easily in github actions (due to missing libssl) so limit it to Windows-->
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;$(TargetFrameworks)</TargetFrameworks>
     <AssemblyName>NetEscapades.AspNetCore.SecurityHeaders.Test</AssemblyName>
     <PackageId>NetEscapades.AspNetCore.SecurityHeaders.Test</PackageId>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
It has issues with libssl on the `ubuntu-latest` in GitHub Actions, so not worth the hassle