### PR TITLE
Add support for trusted types CSP directive

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspBuilder.cs
@@ -198,6 +198,35 @@ public class CspBuilder
     public ReportToDirectiveBuilder AddReportTo(string groupName) => AddDirective(new ReportToDirectiveBuilder(groupName));
 
     /// <summary>
+    /// The <c>require-trusted-types-for</c> directive instructs user agents
+    /// to control the data passed to DOM XSS sink functions, like
+    /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML">Element.innerHTML</see>
+    /// setter.
+    ///
+    /// When used, those functions only accept non-spoofable, typed values created by Trusted Type
+    /// policies, and reject strings. Together with <see cref="AddTrustedTypes"/> which
+    /// guards creation of Trusted Type policies, this allows authors to define rules guarding
+    /// writing values to the DOM and thus reducing the DOM XSS attack surface to small,
+    /// isolated parts of the web application codebase, facilitating their monitoring and code review.
+    /// </summary>
+    /// <returns>A configured <see cref="RequireTrustedTypesForDirectiveBuilder"/></returns>
+    public RequireTrustedTypesForDirectiveBuilder AddRequireTrustedTypesFor() => AddDirective(new RequireTrustedTypesForDirectiveBuilder());
+
+    /// <summary>
+    /// The <c>trusted-types</c> directive instructs user agents
+    /// to restrict the creation of Trusted Types policies - functions that build non-spoofable,
+    /// typed values intended to be passed to DOM XSS sinks in place of strings.
+    ///
+    /// Together with <see cref="AddRequireTrustedTypesFor"/> this allows authors
+    /// to define rules guarding writing values to the DOM and thus reducing the DOM XSS attack
+    /// surface to small, isolated parts of the web application codebase, facilitating their
+    /// monitoring and code review. This directive declares an allowlist of trusted type policy names
+    /// created with <c>trustedTypes.createPolicy</c> from Trusted Types API.
+    /// </summary>
+    /// <returns>A configured <see cref="RequireTrustedTypesForDirectiveBuilder"/></returns>
+    public TrustedTypesDirectiveBuilder AddTrustedTypes() => AddDirective(new TrustedTypesDirectiveBuilder());
+
+    /// <summary>
     /// Create a custom CSP directive for an un-implemented directive
     /// </summary>
     /// <param name="directive">The directive name, e.g. default-src</param>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/RequireTrustedTypesForDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/RequireTrustedTypesForDirectiveBuilder.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
+
+/// <summary>
+/// The <c>require-trusted-types-for</c> directive instructs user agents
+/// to control the data passed to DOM XSS sink functions, like
+/// <see href="https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML">Element.innerHTML</see>
+/// setter.
+///
+/// When used, those functions only accept non-spoofable, typed values created by Trusted Type
+/// policies, and reject strings. Together with <see cref="TrustedTypesDirectiveBuilder"/> which
+/// guards creation of Trusted Type policies, this allows authors to define rules guarding
+/// writing values to the DOM and thus reducing the DOM XSS attack surface to small,
+/// isolated parts of the web application codebase, facilitating their monitoring and code review.
+/// </summary>
+public class RequireTrustedTypesForDirectiveBuilder : CspDirectiveBuilderBase
+{
+    private const string Separator = " ";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequireTrustedTypesForDirectiveBuilder"/> class.
+    /// </summary>
+    public RequireTrustedTypesForDirectiveBuilder() : base("require-trusted-types-for")
+    {
+    }
+
+    /// <summary>
+    /// The sink groups tokens to apply.
+    /// </summary>
+    private List<string> SinkGroups { get; } = new(1); // using a single capacity because currently only 1 group is defined
+
+    /// <summary>
+    /// Mark the <c>script</c> sink group as requiring trusted values
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public RequireTrustedTypesForDirectiveBuilder Script()
+    {
+        SinkGroups.Add("'script'");
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom sink group to the required-trusted-types-for directive.
+    /// Useful for adding experimental sink group.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    /// <param name="sinkGroup">The sink group to add</param>
+    public RequireTrustedTypesForDirectiveBuilder AddCustomSinkGroup(string sinkGroup)
+    {
+        SinkGroups.Add(sinkGroup);
+        return this;
+    }
+
+    /// <inheritdoc />
+    internal override Func<HttpContext, string> CreateBuilder()
+    {
+        // Technically, no sink groups is a misconfiguration
+        // TODO: report this in ILogger somehow
+        var sinkGroups = string.Join(Separator, SinkGroups);
+        var result = string.IsNullOrEmpty(sinkGroups) ? Directive : $"{Directive} {sinkGroups}";
+
+        return _ => result;
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/RequireTrustedTypesForDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/RequireTrustedTypesForDirectiveBuilder.cs
@@ -48,7 +48,7 @@ public class RequireTrustedTypesForDirectiveBuilder : CspDirectiveBuilderBase
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     /// <param name="sinkGroup">The sink group to add</param>
-    public RequireTrustedTypesForDirectiveBuilder AddCustomSinkGroup(string sinkGroup)
+    public RequireTrustedTypesForDirectiveBuilder CustomSinkGroup(string sinkGroup)
     {
         SinkGroups.Add(sinkGroup);
         return this;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/TrustedTypesDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/TrustedTypesDirectiveBuilder.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using NetEscapades.AspNetCore.SecurityHeaders.Helpers;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
+
+/// <summary>
+/// The <c>trusted-types</c> directive instructs user agents
+/// to restrict the creation of Trusted Types policies - functions that build non-spoofable,
+/// typed values intended to be passed to DOM XSS sinks in place of strings.
+///
+/// Together with <see cref="RequireTrustedTypesForDirectiveBuilder"/> this allows authors
+/// to define rules guarding writing values to the DOM and thus reducing the DOM XSS attack
+/// surface to small, isolated parts of the web application codebase, facilitating their
+/// monitoring and code review. This directive declares an allowlist of trusted type policy names
+/// created with <c>trustedTypes.createPolicy</c> from Trusted Types API.
+/// </summary>
+public class TrustedTypesDirectiveBuilder : CspDirectiveBuilderBase
+{
+    private const string Separator = " ";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TrustedTypesDirectiveBuilder"/> class.
+    /// </summary>
+    public TrustedTypesDirectiveBuilder() : base("trusted-types")
+    {
+    }
+
+    /// <summary>
+    /// The policies to apply.
+    /// </summary>
+    private List<string> Policies { get; } = new();
+
+    /// <summary>
+    /// Allows for creating policies with a name that was already used.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public TrustedTypesDirectiveBuilder AllowDuplicates()
+    {
+        Policies.Add("'allow-duplicates'");
+        return this;
+    }
+
+    /// <summary>
+    /// Disallows creating any Trusted Type policy (same as not specifying any policyName).
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public TrustedTypesDirectiveBuilder None()
+    {
+        Policies.Add("'none'");
+        return this;
+    }
+
+    /// <summary>
+    /// Allows creating any Trusted Type policy (same as not specifying any policyName).
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public TrustedTypesDirectiveBuilder Any()
+    {
+        Policies.Add("'none'");
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a policy name to the allow-list for trusted type policies. A valid policy
+    /// name consists only of alphanumeric characters, or one of <c>-#=_/@.%</c>
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    /// <param name="policyName">The policy name to add</param>
+    public TrustedTypesDirectiveBuilder AddPolicyName(string policyName)
+    {
+        foreach (var c in policyName)
+        {
+            if (!char.IsLetterOrDigit(c)
+                && c is not ('-' or '#' or '=' or '_' or '/' or '@' or '.' or '%'))
+            {
+                ThrowHelpers.ThrowArgumentException(
+                    nameof(policyName),
+                    $"Trusted type policy name '{policyName}' is invalid. Policy names must contain only alphanumeric characters or one of -#=_/@.%");
+            }
+        }
+
+        Policies.Add(policyName);
+        return this;
+    }
+
+    /// <inheritdoc />
+    internal override Func<HttpContext, string> CreateBuilder()
+    {
+        var policies = string.Join(Separator, Policies);
+        var result = string.IsNullOrEmpty(policies) ? Directive : $"{Directive} {policies}";
+
+        return _ => result;
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/TrustedTypesDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/TrustedTypesDirectiveBuilder.cs
@@ -58,7 +58,7 @@ public class TrustedTypesDirectiveBuilder : CspDirectiveBuilderBase
     /// <returns>The CSP builder for method chaining</returns>
     public TrustedTypesDirectiveBuilder Any()
     {
-        Policies.Add("'none'");
+        Policies.Add("*");
         return this;
     }
 
@@ -68,7 +68,7 @@ public class TrustedTypesDirectiveBuilder : CspDirectiveBuilderBase
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     /// <param name="policyName">The policy name to add</param>
-    public TrustedTypesDirectiveBuilder AddPolicyName(string policyName)
+    public TrustedTypesDirectiveBuilder AllowPolicy(string policyName)
     {
         foreach (var c in policyName)
         {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Helpers/ThrowHelpers.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Helpers/ThrowHelpers.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Helpers;
+
+/// <summary>
+/// Throw helpers to shim runtime behaviour
+/// </summary>
+internal static class ThrowHelpers
+{
+    /// <summary>
+    /// Throw an argument exception with the provided method
+    /// </summary>
+    /// <param name="paramName">The parameter name</param>
+    /// <param name="message">The message name</param>
+    [DoesNotReturn]
+    public static void ThrowArgumentException(string paramName, string message)
+    {
+        throw new ArgumentException(message, paramName);
+    }
+}

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
@@ -501,8 +501,8 @@ public class CspBuilderTests
         var builder = new CspBuilder();
 
         builder.AddTrustedTypes()
-            .AddPolicyName("one")
-            .AddPolicyName("two")
+            .AllowPolicy("one")
+            .AllowPolicy("two")
             .AllowDuplicates();
         var result = builder.Build();
 
@@ -528,7 +528,7 @@ public class CspBuilderTests
         builder.AddTrustedTypes().Any();
         var result = builder.Build();
 
-        result.ConstantValue.Should().Be("trusted-types 'none'");
+        result.ConstantValue.Should().Be("trusted-types *");
     }
 
     [Theory]
@@ -539,7 +539,7 @@ public class CspBuilderTests
     {
         var builder = new CspBuilder();
 
-        var method = () => builder.AddTrustedTypes().AddPolicyName(policyName);
+        var method = () => builder.AddTrustedTypes().AllowPolicy(policyName);
 
         method.Should().Throw<ArgumentException>();
     }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
@@ -485,6 +485,66 @@ public class CspBuilderTests
     }
 
     [Fact]
+    public void Build_RequireTrustedTypesFor_AddsValue()
+    {
+        var builder = new CspBuilder();
+        
+        builder.AddRequireTrustedTypesFor().Script();
+        var result = builder.Build();
+
+        result.ConstantValue.Should().Be("require-trusted-types-for 'script'");
+    }
+
+    [Fact]
+    public void Build_TrustedTypes_AddsValue()
+    {
+        var builder = new CspBuilder();
+
+        builder.AddTrustedTypes()
+            .AddPolicyName("one")
+            .AddPolicyName("two")
+            .AllowDuplicates();
+        var result = builder.Build();
+
+        result.ConstantValue.Should().Be("trusted-types one two 'allow-duplicates'");
+    }
+
+    [Fact]
+    public void Build_TrustedTypes_AddsNone()
+    {
+        var builder = new CspBuilder();
+
+        builder.AddTrustedTypes().None();
+        var result = builder.Build();
+
+        result.ConstantValue.Should().Be("trusted-types 'none'");
+    }
+
+    [Fact]
+    public void Build_TrustedTypes_AddsAny()
+    {
+        var builder = new CspBuilder();
+
+        builder.AddTrustedTypes().Any();
+        var result = builder.Build();
+
+        result.ConstantValue.Should().Be("trusted-types 'none'");
+    }
+
+    [Theory]
+    [InlineData("*")]
+    [InlineData("Oops!")]
+    [InlineData(" ")]
+    public void Build_TrustedTypes_RejectsInvalidValues(string policyName)
+    {
+        var builder = new CspBuilder();
+
+        var method = () => builder.AddTrustedTypes().AddPolicyName(policyName);
+
+        method.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
     public void Build_CustomDirective_AddsValues()
     {
         var builder = new CspBuilder();

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -72,6 +72,7 @@ namespace Microsoft.AspNetCore.Builder
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ObjectSourceDirectiveBuilder AddObjectSrc() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ReportToDirectiveBuilder AddReportTo(string groupName) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ReportUriDirectiveBuilder AddReportUri() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.RequireTrustedTypesForDirectiveBuilder AddRequireTrustedTypesFor() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.SandboxDirectiveBuilder AddSandbox() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder AddScriptSrc() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceAttrDirectiveBuilder AddScriptSrcAttr() { }
@@ -79,6 +80,7 @@ namespace Microsoft.AspNetCore.Builder
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder AddStyleSrc() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceAttrDirectiveBuilder AddStyleSrcAttr() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder AddStyleSrcElem() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.TrustedTypesDirectiveBuilder AddTrustedTypes() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.UpgradeInsecureRequestsDirectiveBuilder AddUpgradeInsecureRequests() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.WorkerSourceDirectiveBuilder AddWorkerSrc() { }
     }
@@ -381,6 +383,12 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public ReportUriDirectiveBuilder() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CspDirectiveBuilderBase To(string uri) { }
     }
+    public class RequireTrustedTypesForDirectiveBuilder : NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CspDirectiveBuilderBase
+    {
+        public RequireTrustedTypesForDirectiveBuilder() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.RequireTrustedTypesForDirectiveBuilder CustomSinkGroup(string sinkGroup) { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.RequireTrustedTypesForDirectiveBuilder Script() { }
+    }
     public class SandboxDirectiveBuilder : NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CspDirectiveBuilderBase
     {
         public SandboxDirectiveBuilder() { }
@@ -434,6 +442,14 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public StyleSourceElemDirectiveBuilder() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder ReportSample() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder WithHashTagHelper() { }
+    }
+    public class TrustedTypesDirectiveBuilder : NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CspDirectiveBuilderBase
+    {
+        public TrustedTypesDirectiveBuilder() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.TrustedTypesDirectiveBuilder AllowDuplicates() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.TrustedTypesDirectiveBuilder AllowPolicy(string policyName) { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.TrustedTypesDirectiveBuilder Any() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.TrustedTypesDirectiveBuilder None() { }
     }
     public class UpgradeInsecureRequestsDirectiveBuilder : NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CspDirectiveBuilderBase
     {


### PR DESCRIPTION
See

- https://www.w3.org/TR/trusted-types
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types

Fixes #138 