### PR TITLE
Remove obsolete APIs

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollection.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/HeaderPolicyCollection.cs
@@ -26,38 +26,4 @@ public class HeaderPolicyCollection : Dictionary<string, IHeaderPolicy>, IReadOn
         : base(other)
     {
     }
-
-    /// <summary>
-    /// Apply document-based headers such as Content-Security-Policy to all responses serving the provided
-    /// content-type prefixes.
-    /// </summary>
-    /// <param name="contentTypes">The content-type response prefixes to apply the headers to. For example, using
-    /// <c>new [] { "text/" }</c> would cause all document-based headers to be applied only to responses
-    /// returning content-types such as <c>"text/plain"</c>, or <c>"text/html"</c></param>
-    /// <remarks>Generally, headers such as Content-Security-Policy only make sense at the document level, so
-    /// they are typically only applied to HTML documents, and to JavaScript (web workers have their own
-    /// policy, <see cref="!:https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#content_security_policy" >MDN</see>
-    /// for details). However, in some cases, you may want to apply your document headers to additional
-    /// content-types.</remarks>
-    /// <returns>The <see cref="HeaderPolicyCollection"/> for chaining</returns>
-    [Obsolete("This method no longer has any effect - all headers are applied to all responses by default.")]
-    public HeaderPolicyCollection ApplyDocumentHeadersToContentTypes(string[] contentTypes)
-    {
-        return this;
-    }
-
-    /// <summary>
-    /// Apply document-based headers such as Content-Security-Policy to all responses, regardless of content-type.
-    /// </summary>
-    /// <remarks>Generally, headers such as Content-Security-Policy only make sense at the document level, so
-    /// they are typically only applied to HTML documents, and to JavaScript (web workers have their own
-    /// policy, <see cref="!:https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#content_security_policy" >MDN</see>
-    /// for details). However, in some cases, you may want to apply your document headers to additional
-    /// content-types.</remarks>
-    /// <returns>The <see cref="HeaderPolicyCollection"/> for chaining</returns>
-    [Obsolete("This method no longer has any effect - all headers are applied to all responses by default.")]
-    public HeaderPolicyCollection ApplyDocumentHeadersToAllResponses()
-    {
-        return this;
-    }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspBuilder.cs
@@ -122,14 +122,6 @@ public class CspBuilder
     public FrameSourceDirectiveBuilder AddFrameSrc() => AddDirective(new FrameSourceDirectiveBuilder());
 
     /// <summary>
-    /// The frame-src directive specifies valid sources for nested browsing contexts loading
-    /// using elements such as  &lt;frame&gt; and  &lt;iframe&gt;
-    /// </summary>
-    /// <returns>A configured <see cref="FrameSourceDirectiveBuilder"/></returns>
-    [Obsolete("Use AddFrameSrc method instead. This method will be removed in a future version of the library.")]
-    public FrameSourceDirectiveBuilder AddFrameSource() => AddDirective(new FrameSourceDirectiveBuilder());
-
-    /// <summary>
     /// The worker-src directive specifies valid sources for Worker, SharedWorker, or ServiceWorker scripts.
     /// </summary>
     /// <returns>A configured <see cref="WorkerSourceDirectiveBuilder"/></returns>

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -62,9 +62,6 @@ namespace Microsoft.AspNetCore.Builder
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FontSourceDirectiveBuilder AddFontSrc() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FormActionDirectiveBuilder AddFormAction() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder AddFrameAncestors() { }
-        [System.Obsolete("Use AddFrameSrc method instead. This method will be removed in a future version o" +
-            "f the library.")]
-        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder AddFrameSource() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder AddFrameSrc() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ImageSourceDirectiveBuilder AddImgSrc() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ManifestSourceDirectiveBuilder AddManifestSrc() { }
@@ -171,12 +168,6 @@ namespace Microsoft.AspNetCore.Builder
     public class HeaderPolicyCollection : System.Collections.Generic.Dictionary<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>>, System.Collections.Generic.IReadOnlyDictionary<string, NetEscapades.AspNetCore.SecurityHeaders.Headers.IHeaderPolicy>, System.Collections.IEnumerable
     {
         public HeaderPolicyCollection() { }
-        [System.Obsolete("This method no longer has any effect - all headers are applied to all responses b" +
-            "y default.")]
-        public Microsoft.AspNetCore.Builder.HeaderPolicyCollection ApplyDocumentHeadersToAllResponses() { }
-        [System.Obsolete("This method no longer has any effect - all headers are applied to all responses b" +
-            "y default.")]
-        public Microsoft.AspNetCore.Builder.HeaderPolicyCollection ApplyDocumentHeadersToContentTypes(string[] contentTypes) { }
     }
     public static class HeaderPolicyCollectionExtensions
     {


### PR DESCRIPTION
Remove APIs that were deprecated due to being non-functioning or having direct replacements

Left the other obsolete APIs as they're more related to headers being obsolete than the APIs