### PR TITLE
docs: Enhance documentation by adding code formatting to directive descriptions in CSP builders

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/BaseUriDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/BaseUriDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The base-uri directive restricts the URLs which can be used in a document's
+/// The <c>base-uri</c> directive restricts the URLs which can be used in a document's
 /// &lt;base&gt; element. If this value is absent, then any URI is allowed. If this
 /// directive is absent, the user agent will use the value in the &lt;base&gt; element.
 /// </summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/BlockAllMixedContentDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/BlockAllMixedContentDirectiveBuilder.cs
@@ -4,14 +4,14 @@ using Microsoft.AspNetCore.Http;
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The block-all-mixed-content directive prevents loading any assets using
+/// The <c>block-all-mixed-content</c> directive prevents loading any assets using
 /// HTTP when the page is loaded using HTTPS.
 ///
 /// All mixed content resource requests are blocked, including both active
 /// and passive mixed content. This also applies to &lt;iframe&gt; documents,
 /// ensuring the entire page is mixed content free.
 ///
-/// The upgrade-insecure-requests directive is evaluated before block-all-mixed-content
+/// The <c>upgrade-insecure-requests</c> directive is evaluated before <c>block-all-mixed-content</c>
 /// and If the former is set, the latter is effectively a no-op.
 /// It is recommended to set one directive or the other – not both.
 /// </summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ConnectSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ConnectSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The connect-src directive restricts the URLs which can be loaded using script interfaces
+/// The <c>connect-src</c> directive restricts the URLs which can be loaded using script interfaces
 /// The APIs that are restricted are:  &lt;a&gt; ping, Fetch, XMLHttpRequest, WebSocket, and EventSource.
 /// </summary>
 public class ConnectSourceDirectiveBuilder : CspDirectiveBuilder

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/CspBuilder.cs
@@ -17,7 +17,7 @@ public class CspBuilder
         new Dictionary<string, CspDirectiveBuilderBase>();
 
     /// <summary>
-    /// The default-src directive serves as a fallback for the other CSP fetch directives.
+    /// The <c>default-src</c> directive serves as a fallback for the other CSP fetch directives.
     /// Valid sources include 'self', 'unsafe-inline', 'unsafe-eval', 'none', scheme such as http:,
     /// or internet hosts by name or IP address, as well as an optional URL scheme and/or port number.
     /// The site's address may include an optional leading wildcard (the asterisk character, '*'), and
@@ -27,87 +27,87 @@ public class CspBuilder
     public DefaultSourceDirectiveBuilder AddDefaultSrc() => AddDirective(new DefaultSourceDirectiveBuilder());
 
     /// <summary>
-    /// The connect-src directive restricts the URLs which can be loaded using script interfaces
+    /// The <c>connect-src</c> directive restricts the URLs which can be loaded using script interfaces
     /// The APIs that are restricted are:  &lt;a&gt; ping, Fetch, XMLHttpRequest, WebSocket, and EventSource.
     /// </summary>
     /// <returns>A configured <see cref="ConnectSourceDirectiveBuilder"/></returns>
     public ConnectSourceDirectiveBuilder AddConnectSrc() => AddDirective(new ConnectSourceDirectiveBuilder());
 
     /// <summary>
-    /// The font-src directive specifies valid sources for fonts loaded using @font-face.
+    /// The <c>font-src</c> directive specifies valid sources for fonts loaded using <see href="https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face">@font-face</see>.
     /// </summary>
     /// <returns>A configured <see cref="FontSourceDirectiveBuilder"/></returns>
     public FontSourceDirectiveBuilder AddFontSrc() => AddDirective(new FontSourceDirectiveBuilder());
 
     /// <summary>
-    /// The object-src directive specifies valid sources for the &lt;object&gt;, &lt;embed&gt;, and &lt;applet&gt; elements
+    /// The <c>object-src</c> directive specifies valid sources for the &lt;object&gt;, &lt;embed&gt;, and &lt;applet&gt; elements
     /// </summary>
     /// <returns>A configured <see cref="ObjectSourceDirectiveBuilder"/></returns>
     public ObjectSourceDirectiveBuilder AddObjectSrc() => AddDirective(new ObjectSourceDirectiveBuilder());
 
     /// <summary>
-    /// The form-action directive restricts the URLs which can be used as the target of a form submissions from a given context
+    /// The <c>form-action</c> directive restricts the URLs which can be used as the target of a form submissions from a given context
     /// </summary>
     /// <returns>A configured <see cref="FormActionDirectiveBuilder"/></returns>
     public FormActionDirectiveBuilder AddFormAction() => AddDirective(new FormActionDirectiveBuilder());
 
     /// <summary>
-    /// The img-src directive specifies valid sources of images and favicons
+    /// The <c>img-src</c> directive specifies valid sources of images and favicons>
     /// </summary>
     /// <returns>A configured <see cref="ImageSourceDirectiveBuilder"/></returns>
     public ImageSourceDirectiveBuilder AddImgSrc() => AddDirective(new ImageSourceDirectiveBuilder());
 
     /// <summary>
-    /// The script-src directive specifies valid sources for sources for JavaScript.
+    /// The <c>script-src</c> directive specifies valid sources for sources for JavaScript.
     /// </summary>
     /// <returns>A configured <see cref="ScriptSourceDirectiveBuilder"/></returns>
     public ScriptSourceDirectiveBuilder AddScriptSrc() => AddDirective(new ScriptSourceDirectiveBuilder());
 
     /// <summary>
-    /// The script-src-attr directive specifies valid sources for JavaScript inline event handlers.
+    /// The <c>script-src-attr</c> directive specifies valid sources for JavaScript inline event handlers.
     /// </summary>
     /// <returns>A configured <see cref="ScriptSourceAttrDirectiveBuilder"/></returns>
     public ScriptSourceAttrDirectiveBuilder AddScriptSrcAttr() => AddDirective(new ScriptSourceAttrDirectiveBuilder());
 
     /// <summary>
-    /// The script-src-elem directive specifies valid sources for JavaScript &lt;script&gt; elements.
+    /// The <c>script-src-elem</c> directive specifies valid sources for JavaScript &lt;script&gt; elements.
     /// </summary>
     /// <returns>A configured <see cref="ScriptSourceAttrDirectiveBuilder"/></returns>
     public ScriptSourceElemDirectiveBuilder AddScriptSrcElem() => AddDirective(new ScriptSourceElemDirectiveBuilder());
 
     /// <summary>
-    /// The style-src directive specifies valid sources for sources for stylesheets.
+    /// The <c>style-src</c> directive specifies valid sources for sources for stylesheets.
     /// </summary>
     /// <returns>A configured <see cref="StyleSourceDirectiveBuilder"/></returns>
     public StyleSourceDirectiveBuilder AddStyleSrc() => AddDirective(new StyleSourceDirectiveBuilder());
 
     /// <summary>
-    /// The style-src-attr directive specifies valid sources for inline styles applied to individual DOM elements.
+    /// The <c>style-src-attr</c> directive specifies valid sources for inline styles applied to individual DOM elements.
     /// </summary>
     /// <returns>A configured <see cref="StyleSourceAttrDirectiveBuilder"/></returns>
     public StyleSourceAttrDirectiveBuilder AddStyleSrcAttr() => AddDirective(new StyleSourceAttrDirectiveBuilder());
 
     /// <summary>
-    /// The style-src-elem directive specifies valid sources for stylesheet &lt;style&gt; elements
+    /// The <c>style-src-elem</c> directive specifies valid sources for stylesheet &lt;style&gt; elements
     /// and &lt;link&gt; elements with rel="stylesheet".
     /// </summary>
     /// <returns>A configured <see cref="StyleSourceAttrDirectiveBuilder"/></returns>
     public StyleSourceElemDirectiveBuilder AddStyleSrcElem() => AddDirective(new StyleSourceElemDirectiveBuilder());
 
     /// <summary>
-    /// The media-src directive specifies valid sources for loading media using the &lt;audio&gt; and &lt;video&gt; elements
+    /// The <c>media-src</c> directive specifies valid sources for loading media using the &lt;audio&gt; and &lt;video&gt; elements
     /// </summary>
     /// <returns>A configured <see cref="MediaSourceDirectiveBuilder"/></returns>
     public MediaSourceDirectiveBuilder AddMediaSrc() => AddDirective(new MediaSourceDirectiveBuilder());
 
     /// <summary>
-    /// The manifest-src directive specifies which manifest can be applied to the resource.
+    /// The <c>manifest-src</c> directive specifies which manifest can be applied to the resource.
     /// </summary>
     /// <returns>A configured <see cref="ManifestSourceDirectiveBuilder"/></returns>
     public ManifestSourceDirectiveBuilder AddManifestSrc() => AddDirective(new ManifestSourceDirectiveBuilder());
 
     /// <summary>
-    /// The frame-ancestors directive specifies valid parents that may embed a page using
+    /// The <c>frame-ancestors</c> directive specifies valid parents that may embed a page using
     /// &lt;frame&gt;, &lt;iframe&gt;, &lt;object&gt;, &lt;embed&gt;, or &lt;applet&gt;.
     /// Setting this directive to 'none' is similar to X-Frame-Options: DENY (which is also supported in older browsers).
     /// </summary>
@@ -115,20 +115,20 @@ public class CspBuilder
     public FrameAncestorsDirectiveBuilder AddFrameAncestors() => AddDirective(new FrameAncestorsDirectiveBuilder());
 
     /// <summary>
-    /// The frame-src directive specifies valid sources for nested browsing contexts loading
+    /// The <c>frame-src</c> directive specifies valid sources for nested browsing contexts loading
     /// using elements such as  &lt;frame&gt; and  &lt;iframe&gt;
     /// </summary>
     /// <returns>A configured <see cref="FrameSourceDirectiveBuilder"/></returns>
     public FrameSourceDirectiveBuilder AddFrameSrc() => AddDirective(new FrameSourceDirectiveBuilder());
 
     /// <summary>
-    /// The worker-src directive specifies valid sources for Worker, SharedWorker, or ServiceWorker scripts.
+    /// The <c>worker-src</c> directive specifies valid sources for Worker, SharedWorker, or ServiceWorker scripts.
     /// </summary>
     /// <returns>A configured <see cref="WorkerSourceDirectiveBuilder"/></returns>
     public WorkerSourceDirectiveBuilder AddWorkerSrc() => AddDirective(new WorkerSourceDirectiveBuilder());
 
     /// <summary>
-    /// The base-uri directive restricts the URLs which can be used in a document's
+    /// The <c>base-uri</c> directive restricts the URLs which can be used in a document's
     /// &lt;base&gt; element. If this value is absent, then any URI is allowed. If this
     /// directive is absent, the user agent will use the value in the &lt;base&gt; element.
     /// </summary>
@@ -136,7 +136,7 @@ public class CspBuilder
     public BaseUriDirectiveBuilder AddBaseUri() => AddDirective(new BaseUriDirectiveBuilder());
 
     /// <summary>
-    /// The sandbox directive enables a sandbox for the requested resource similar
+    /// The <c>sandbox</c> directive enables a sandbox for the requested resource similar
     /// to the &lt;script&gt; sandbox attribute. It applies restrictions to a
     /// page's actions including preventing popups, preventing the execution
     /// of plugins and scripts, and enforcing a same-origin policy.
@@ -145,7 +145,7 @@ public class CspBuilder
     public SandboxDirectiveBuilder AddSandbox() => AddDirective(new SandboxDirectiveBuilder());
 
     /// <summary>
-    /// The upgrade-insecure-requests directive instructs user agents to treat all of a
+    /// The <c>upgrade-insecure-requests</c> directive instructs user agents to treat all of a
     /// site's insecure URLs (those served over HTTP) as though they have been
     /// replaced with secure URLs (those served over HTTPS). This directive is
     /// intended for web sites with large numbers of insecure legacy URLs that need to be rewritten.
@@ -154,14 +154,14 @@ public class CspBuilder
     public UpgradeInsecureRequestsDirectiveBuilder AddUpgradeInsecureRequests() => AddDirective(new UpgradeInsecureRequestsDirectiveBuilder());
 
     /// <summary>
-    /// The block-all-mixed-content directive prevents loading any assets using
+    /// The <c>block-all-mixed-content</c> directive prevents loading any assets using
     /// HTTP when the page is loaded using HTTPS.
     ///
     /// All mixed content resource requests are blocked, including both active
     /// and passive mixed content. This also applies to &lt;iframe&gt; documents,
     /// ensuring the entire page is mixed content free.
     ///
-    /// The upgrade-insecure-requests directive is evaluated before block-all-mixed-content
+    /// The <c>upgrade-insecure-requests</c> directive is evaluated before <c>block-all-mixed-content</c>
     /// and If the former is set, the latter is effectively a no-op.
     /// It is recommended to set one directive or the other – not both.
     /// </summary>
@@ -169,17 +169,17 @@ public class CspBuilder
     public BlockAllMixedContentDirectiveBuilder AddBlockAllMixedContent() => AddDirective(new BlockAllMixedContentDirectiveBuilder());
 
     /// <summary>
-    /// The report-uri directive instructs the user agent to report attempts to
+    /// The <c>report-uri</c> directive instructs the user agent to report attempts to
     /// violate the Content Security Policy. These violation reports consist of
     /// JSON documents sent via an HTTP POST request to the specified URI.
     /// </summary>
     /// <returns>A configured <see cref="ReportUriDirectiveBuilder"/></returns>
-    /// /// <remarks>NOTE: this directive has been deprecated in favour of <c>Report-To</c>.
+    /// <remarks>NOTE: this directive has been deprecated in favour of <c>Report-To</c>.
     /// Use <see cref="AddReportTo"/> instead.</remarks>
     public ReportUriDirectiveBuilder AddReportUri() => AddDirective(new ReportUriDirectiveBuilder());
 
     /// <summary>
-    /// The report-to directive instructs the user agent to send requests to
+    /// The <c>report-to</c> directive instructs the user agent to send requests to
     /// an endpoint defined in a <c>Report-To</c> HTTP header. The directive
     /// has no effect in and of itself, but only gains meaning in
     /// combination with other reporting directives.
@@ -221,14 +221,14 @@ public class CspBuilder
     /// <summary>
     /// Create a custom CSP directive for an un-implemented directive
     /// </summary>
-    /// <param name="directive">The directive name, e.g. default-src</param>
+    /// <param name="directive">The directive name, e.g. <c>default-src</c></param>
     /// <returns>A configured <see cref="CustomDirective"/></returns>
     public CustomDirective AddCustomDirective(string directive) => AddDirective(new CustomDirective(directive));
 
     /// <summary>
     /// Create a custom CSP directive for an un-implemented directive
     /// </summary>
-    /// <param name="directive">The directive name, e.g. default-src</param>
+    /// <param name="directive">The directive name, e.g. <c>default-src</c></param>
     /// <param name="value">The directive value</param>
     /// <returns>A configured <see cref="CustomDirective"/></returns>
     public CustomDirective AddCustomDirective(string directive, string value) => AddDirective(new CustomDirective(directive, value));
@@ -237,7 +237,7 @@ public class CspBuilder
     /// Create a custom CSP directive for an un-implemented directive that uses standard or per-request values such as nonce
     /// To create a custom CSP directive with a fixed value, use <see cref="AddCustomDirective(string)"/>
     /// </summary>
-    /// <param name="directive">The directive name, e.g. default-src</param>
+    /// <param name="directive">The directive name, e.g. <c>default-src</c></param>
     /// <remarks>If you need a directive without a value, use <see cref="AddCustomDirective(string)"/> instead</remarks>
     /// <returns>A configured <see cref="CspDirectiveBuilder"/></returns>
     public CspDirectiveBuilder AddCustomDirectiveBuilder(string directive) => AddDirective(new CspDirectiveBuilder(directive));

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/DefaultSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/DefaultSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The default-src directive serves as a fallback for the other CSP fetch directives.
+/// The <c>default-src</c> directive serves as a fallback for the other CSP fetch directives.
 /// Valid sources include 'self', 'unsafe-inline', 'unsafe-eval', 'none', scheme such as http:,
 /// or internet hosts by name or IP address, as well as an optional URL scheme and/or port number.
 /// The site's address may include an optional leading wildcard (the asterisk character, '*'), and

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FontSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FontSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The font-src directive specifies valid sources for fonts loaded using @font-face.
+/// The <c>font-src</c> directive specifies valid sources for fonts loaded using @font-face.
 /// </summary>
 public class FontSourceDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FormActionDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FormActionDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The form-action directive restricts the URLs which can be used as the target of a form submissions from a given context.
+/// The <c>form-action</c> directive restricts the URLs which can be used as the target of a form submissions from a given context.
 /// </summary>
 public class FormActionDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameAncestorsDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameAncestorsDirectiveBuilder.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Http;
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The frame-ancestors directive specifies valid parents that may embed a page using
+/// The <c>frame-ancestors</c> directive specifies valid parents that may embed a page using
 /// &lt;frame&gt;, &lt;iframe&gt;, &lt;object&gt;, &lt;embed&gt;, or &lt;applet&gt;.
 /// Setting this directive to 'none' is similar to X-Frame-Options: DENY (which is also supported in older browers).
 /// </summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/FrameSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The frame-src directive specifies valid sources for nested browsing contexts loading
+/// The <c>frame-src</c> directive specifies valid sources for nested browsing contexts loading
 /// using elements such as  &lt;frame&gt; and  &lt;iframe&gt;
 /// </summary>
 public class FrameSourceDirectiveBuilder : CspDirectiveBuilder

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ImageSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ImageSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The img-src directive specifies valid sources of images and favicons.
+/// The <c>img-src</c> directive specifies valid sources of images and favicons.
 /// </summary>
 public class ImageSourceDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ManifestSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ManifestSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The manifest-src directive specifies which manifest can be applied to the resource.
+/// The <c>manifest-src</c> directive specifies which manifest can be applied to the resource.
 /// </summary>
 public class ManifestSourceDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/MediaSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/MediaSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The media-src directive specifies valid sources for loading media using the &lt;audio&gt; and &lt;video&gt; elements.
+/// The <c>media-src</c> directive specifies valid sources for loading media using the &lt;audio&gt; and &lt;video&gt; elements.
 /// </summary>
 public class MediaSourceDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ObjectSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ObjectSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The object-src directive specifies valid sources for the &lt;object&gt;, &lt;embed&gt;, and &lt;applet&gt; elements.
+/// The <c>object-src</c> directive specifies valid sources for the &lt;object&gt;, &lt;embed&gt;, and &lt;applet&gt; elements.
 /// </summary>
 public class ObjectSourceDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ReportToDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ReportToDirectiveBuilder.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The report-to directive instructs the user agent to send requests to
+/// The <c>report-to</c> directive instructs the user agent to send requests to
 /// an endpoint defined in a <c>Report-To</c> HTTP header. The directive
 /// has no effect in and of itself, but only gains meaning in
 /// combination with other reporting directives.

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ReportUriDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ReportUriDirectiveBuilder.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The report-uri directive instructs the user agent to report attempts to
+/// The <c>report-uri</c> directive instructs the user agent to report attempts to
 /// violate the Content Security Policy. These violation reports consist of
 /// JSON documents sent via an HTTP POST request to the specified URI.
 /// </summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/SandboxDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/SandboxDirectiveBuilder.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Http;
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The sandbox directive enables a sandbox for the requested resource similar
+/// The <c>sandbox</c> directive enables a sandbox for the requested resource similar
 /// to the &lt;script&gt; sandbox attribute. It applies restrictions to a
 /// page's actions including preventing popups, preventing the execution
 /// of plugins and scripts, and enforcing a same-origin policy.

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceAttrDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceAttrDirectiveBuilder.cs
@@ -1,13 +1,13 @@
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The script-src-attr directive specifies valid sources for JavaScript inline event handlers.
+/// The <c>script-src-attr</c> directive specifies valid sources for JavaScript inline event handlers.
 /// This directive only specifies valid sources for inline script event handlers like onclick.
 ///
 /// It does not apply to other JavaScript sources that can trigger script execution, such as
 /// URLs loaded directly into &lt;script&gt; elements and XSLT stylesheets. (Valid sources
-/// can be specified for all JavaScript script sources using script-src, or just for
-/// &lt;script&gt; elements using script-src-elem.)
+/// can be specified for all JavaScript script sources using <c>script-src</c>, or just for
+/// &lt;script&gt; elements using <c>script-src-elem</c>.)
 /// </summary>
 public class ScriptSourceAttrDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The script-src directive specifies valid sources for sources for JavaScript.
+/// The <c>script-src</c> directive specifies valid sources for sources for JavaScript.
 /// This includes not only URLs loaded directly into &lt;script&gt; elements, but also things
 /// like inline script event handlers (onclick) and XSLT stylesheets which can trigger script execution.
 /// </summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceElemDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceElemDirectiveBuilder.cs
@@ -1,13 +1,13 @@
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The script-src-elem directive specifies valid sources for JavaScript &lt;script&gt; elements.
+/// The <c>script-src-elem</c> directive specifies valid sources for JavaScript &lt;script&gt; elements.
 ///
 /// This directive only specifies valid sources in &lt;script&gt; elements (both script requests
 /// and blocks). It does not apply to other JavaScript sources that can trigger script execution,
 /// such as inline script event handlers (onclick), script execution methods gated on the
 /// "unsafe-eval" check, and XSLT stylesheets. (Valid sources can be specified for all
-/// JavaScript script sources using script-src, or just for inline script handlers using script-src-attr.)
+/// JavaScript script sources using <c>script-src</c>, or just for inline script handlers using <c>script-src-attr</c>.)
 /// </summary>
 public class ScriptSourceElemDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceAttrDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceAttrDirectiveBuilder.cs
@@ -1,10 +1,10 @@
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The style-src-attr directive specifies valid sources for inline styles applied to individual DOM elements.
+/// The <c>style-src-attr</c> directive specifies valid sources for inline styles applied to individual DOM elements.
 ///
 /// The directive does not set valid sources for &lt;style&gt; elements and &lt;link&gt; elements with rel="stylesheet".
-/// These are set using style-src-elem (and valid sources for all styles may be set with style-src).
+/// These are set using <c>style-src-elem</c> (and valid sources for all styles may be set with <c>style-src</c>).
 /// </summary>
 public class StyleSourceAttrDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The style-src directive specifies valid sources for sources for stylesheets.
+/// The <c>style-src</c> directive specifies valid sources for sources for stylesheets.
 /// </summary>
 public class StyleSourceDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceElemDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceElemDirectiveBuilder.cs
@@ -1,11 +1,11 @@
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The style-src-elem directive specifies valid sources for stylesheet &lt;style&gt; elements
+/// The <c>style-src-elem</c> directive specifies valid sources for stylesheet &lt;style&gt; elements
 /// and &lt;link&gt; elements with rel="stylesheet".
 ///
 /// The directive does not set valid sources for inline style attributes; these are
-/// set using style-src-attr (and valid sources for all styles may be set with style-src).
+/// set using <c>style-src-attr</c> (and valid sources for all styles may be set with <c>style-src</c>).
 /// </summary>
 public class StyleSourceElemDirectiveBuilder : CspDirectiveBuilder
 {

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/UpgradeInsecureRequestsDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/UpgradeInsecureRequestsDirectiveBuilder.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The upgrade-insecure-requests directive instructs user agents to treat all of a
+/// The <c>upgrade-insecure-requests</c> directive instructs user agents to treat all of a
 /// site's insecure URLs (those served over HTTP) as though they have been
 /// replaced with secure URLs (those served over HTTPS). This directive is
 /// intended for web sites with large numbers of insecure legacy URLs that need to be rewritten.

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/WorkerSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/WorkerSourceDirectiveBuilder.cs
@@ -1,7 +1,7 @@
 namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 
 /// <summary>
-/// The worker-src directive specifies valid sources for Worker, SharedWorker, or ServiceWorker scripts.
+/// The <c>worker-src</c> directive specifies valid sources for Worker, SharedWorker, or ServiceWorker scripts.
 /// </summary>
 public class WorkerSourceDirectiveBuilder : CspDirectiveBuilder
 {


### PR DESCRIPTION
also, what is the plan for docs here? github pages with docfx?

if this a vscode issue?
![image](https://github.com/user-attachments/assets/027c1abb-b82a-4b4f-8d8b-f5badbb806fd)
![image](https://github.com/user-attachments/assets/2de1d8a8-47e4-4779-b2e7-9cd38c073ad1)
the docs seem correct but vscode doesn't render right (note the multiple `,,,,,`)