### PR TITLE
Add API for supporting policy selectors that need to make async calls

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderOptions.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/CustomHeaderOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 
 namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure;
@@ -23,7 +24,7 @@ internal class CustomHeaderOptions
     /// <summary>
     /// The policy selector function
     /// </summary>
-    public Func<PolicySelectorContext, IReadOnlyHeaderPolicyCollection>? PolicySelector { get; set; }
+    public Func<PolicySelectorContext, ValueTask<IReadOnlyHeaderPolicyCollection>>? PolicySelector { get; set; }
 
     /// <summary>
     /// Gets the policy based on the <paramref name="name"/>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/SecurityHeaderPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/SecurityHeaderPolicyBuilder.cs
@@ -92,7 +92,7 @@ public class SecurityHeaderPolicyBuilder
     /// <param name="policySelector">A function to invoke just before applying policies to a response,
     /// to select the policy to use. The final policy to execute should be returned from the function.</param>
     /// <returns>The <see cref="SecurityHeaderPolicyBuilder"/> for chaining</returns>
-    public SecurityHeaderPolicyBuilder SetPolicySelectorAsync(
+    public SecurityHeaderPolicyBuilder SetAsyncPolicySelector(
         Func<PolicySelectorContext, ValueTask<IReadOnlyHeaderPolicyCollection>> policySelector)
     {
         _options.PolicySelector = policySelector;

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/SecurityHeaderPolicyBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Infrastructure/SecurityHeaderPolicyBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
@@ -80,6 +81,19 @@ public class SecurityHeaderPolicyBuilder
     /// <returns>The <see cref="SecurityHeaderPolicyBuilder"/> for chaining</returns>
     public SecurityHeaderPolicyBuilder SetPolicySelector(
         Func<PolicySelectorContext, IReadOnlyHeaderPolicyCollection> policySelector)
+    {
+        _options.PolicySelector = ctx => new ValueTask<IReadOnlyHeaderPolicyCollection>(policySelector(ctx));
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the policy selector. Use this to customise a policy before it's applied to the request.
+    /// </summary>
+    /// <param name="policySelector">A function to invoke just before applying policies to a response,
+    /// to select the policy to use. The final policy to execute should be returned from the function.</param>
+    /// <returns>The <see cref="SecurityHeaderPolicyBuilder"/> for chaining</returns>
+    public SecurityHeaderPolicyBuilder SetPolicySelectorAsync(
+        Func<PolicySelectorContext, ValueTask<IReadOnlyHeaderPolicyCollection>> policySelector)
     {
         _options.PolicySelector = policySelector;
         return this;

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -1014,5 +1014,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetDefaultPolicy(Microsoft.AspNetCore.Builder.HeaderPolicyCollection policyCollection) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetDefaultPolicy(System.Action<Microsoft.AspNetCore.Builder.HeaderPolicyCollection> configurePolicy) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetPolicySelector(System.Func<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.PolicySelectorContext, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection> policySelector) { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetPolicySelectorAsync(System.Func<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.PolicySelectorContext, System.Threading.Tasks.ValueTask<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection>> policySelector) { }
     }
 }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -1011,9 +1011,9 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Infrastructure
     {
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder AddPolicy(string name, Microsoft.AspNetCore.Builder.HeaderPolicyCollection policyCollection) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder AddPolicy(string name, System.Action<Microsoft.AspNetCore.Builder.HeaderPolicyCollection> configurePolicy) { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetAsyncPolicySelector(System.Func<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.PolicySelectorContext, System.Threading.Tasks.ValueTask<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection>> policySelector) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetDefaultPolicy(Microsoft.AspNetCore.Builder.HeaderPolicyCollection policyCollection) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetDefaultPolicy(System.Action<Microsoft.AspNetCore.Builder.HeaderPolicyCollection> configurePolicy) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetPolicySelector(System.Func<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.PolicySelectorContext, NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection> policySelector) { }
-        public NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.SecurityHeaderPolicyBuilder SetPolicySelectorAsync(System.Func<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.PolicySelectorContext, System.Threading.Tasks.ValueTask<NetEscapades.AspNetCore.SecurityHeaders.Infrastructure.IReadOnlyHeaderPolicyCollection>> policySelector) { }
     }
 }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareExtensionsTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareExtensionsTests.cs
@@ -113,7 +113,7 @@ public class SecurityHeadersMiddlewareExtensionsTests
                     services.AddSecurityHeaderPolicies().SetPolicySelector(selector);
                     break;
                 case SelectorRegistrationType.Async:
-                    services.AddSecurityHeaderPolicies().SetPolicySelectorAsync(c => new(selector(c)));
+                    services.AddSecurityHeaderPolicies().SetAsyncPolicySelector(c => new(selector(c)));
                     break;
                 case SelectorRegistrationType.Func:
                     services.AddSecurityHeaderPolicies(o => o.SetPolicySelector(selector));

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareExtensionsTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -85,33 +86,39 @@ public class SecurityHeadersMiddlewareExtensionsTests
 
     [Test]
     [MatrixDataSource]
-    public void AddSecurityHeaderPolicies_OverwritesPreviousPolicySelector(
-        [Matrix] RegistrationType first,
-        [Matrix] RegistrationType second)
+    public async Task AddSecurityHeaderPolicies_OverwritesPreviousPolicySelector(
+        [Matrix] SelectorRegistrationType first,
+        [Matrix] SelectorRegistrationType second)
     {
+        IReadOnlyHeaderPolicyCollection policy1 = new HeaderPolicyCollection();
+        IReadOnlyHeaderPolicyCollection policy2 = new HeaderPolicyCollection();
         var serviceCollection = new ServiceCollection();
-        Func<PolicySelectorContext, IReadOnlyHeaderPolicyCollection> selector1 = x => x.DefaultPolicy;
-        Func<PolicySelectorContext, IReadOnlyHeaderPolicyCollection> selector2 = x => x.DefaultPolicy;
+        Func<PolicySelectorContext, IReadOnlyHeaderPolicyCollection> selector1 = _ => policy1;
+        Func<PolicySelectorContext, IReadOnlyHeaderPolicyCollection> selector2 = _ => policy2;
         SetSelector(serviceCollection, first, selector1);
         SetSelector(serviceCollection, second, selector2);
         var provider = serviceCollection.BuildServiceProvider();
         var opts = SecurityHeadersMiddlewareExtensions.GetOptions(provider);
         
         opts.Should().NotBeNull();
-        opts.PolicySelector.Should().BeSameAs(selector2);
+        opts.PolicySelector.Should().NotBeNull();
+        var policy = await opts.PolicySelector.Invoke(new PolicySelectorContext());
 
-        static void SetSelector(ServiceCollection services, RegistrationType type,
+        static void SetSelector(ServiceCollection services, SelectorRegistrationType type,
             Func<PolicySelectorContext, IReadOnlyHeaderPolicyCollection> selector)
         {
             switch (type)
             {
-                case RegistrationType.Direct:
+                case SelectorRegistrationType.Direct:
                     services.AddSecurityHeaderPolicies().SetPolicySelector(selector);
                     break;
-                case RegistrationType.Func:
+                case SelectorRegistrationType.Async:
+                    services.AddSecurityHeaderPolicies().SetPolicySelectorAsync(c => new(selector(c)));
+                    break;
+                case SelectorRegistrationType.Func:
                     services.AddSecurityHeaderPolicies(o => o.SetPolicySelector(selector));
                     break;
-                case RegistrationType.FuncWithProvider:
+                case SelectorRegistrationType.FuncWithProvider:
                     services.AddSecurityHeaderPolicies((o, _) => o.SetPolicySelector(selector));
                     break;
                 default:
@@ -144,6 +151,14 @@ public class SecurityHeadersMiddlewareExtensionsTests
 
     public enum RegistrationType
     {
+        Direct,
+        Func,
+        FuncWithProvider
+    }
+
+    public enum SelectorRegistrationType
+    {
+        Async,
         Direct,
         Func,
         FuncWithProvider

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -517,7 +517,7 @@ public class SecurityHeadersMiddlewareTests
             s.AddRouting();
             s.AddSecurityHeaderPolicies()
                 .AddPolicy(policyName, p => p.AddCustomHeader("Custom-Header", "MyValue"))
-                .SetPolicySelectorAsync(ctx =>
+                .SetAsyncPolicySelector(ctx =>
                     new(ctx.SelectedPolicy.Copy().AddCustomHeader("Added-Header", "MyValue")));
         }).Configure(app =>
         {
@@ -556,7 +556,7 @@ public class SecurityHeadersMiddlewareTests
             s.AddRouting();
             s.AddSecurityHeaderPolicies()
                 .AddPolicy(policyName, p => p.AddCustomHeader("Custom-Header", "MyValue"))
-                .SetPolicySelectorAsync(async ctx =>
+                .SetAsyncPolicySelector(async ctx =>
                 {
                     await Task.Yield();
                     return ctx.SelectedPolicy.Copy().AddCustomHeader("Added-Header", "MyValue");
@@ -618,7 +618,7 @@ public class SecurityHeadersMiddlewareTests
         var hostBuilder = new WebHostBuilder()
             .ConfigureServices(s => s
                 .AddSecurityHeaderPolicies()
-                .SetPolicySelectorAsync(ctx => new(result: null!)))
+                .SetAsyncPolicySelector(ctx => new(result: null!)))
             .Configure(app =>
             {
                 app.UseSecurityHeaders();

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -508,6 +508,88 @@ public class SecurityHeadersMiddlewareTests
     }
 
     [Test]
+    public async Task HttpRequest_WithAsyncPolicySelector_CanUseSelectorThatReturnsSynchronously()
+    {
+        var policyName = "custom";
+        // Arrange
+        var hostBuilder = new WebHostBuilder().ConfigureServices(s =>
+        {
+            s.AddRouting();
+            s.AddSecurityHeaderPolicies()
+                .AddPolicy(policyName, p => p.AddCustomHeader("Custom-Header", "MyValue"))
+                .SetPolicySelectorAsync(ctx =>
+                    new(ctx.SelectedPolicy.Copy().AddCustomHeader("Added-Header", "MyValue")));
+        }).Configure(app =>
+        {
+            app.UseSecurityHeaders();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapPut("/", async context =>
+                {
+                    context.Response.ContentType = "text/html";
+                    await context.Response.WriteAsync("Test response");
+                });
+            });
+        });
+
+        using var server = new TestServer(hostBuilder);
+
+        // Act
+        // Actual request.
+        var response = await server.CreateRequest("/").SendAsync("PUT");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+        response.Headers.AssertHttpRequestDefaultSecurityHeaders();
+        response.Headers.Should().ContainKey("Added-Header");
+        response.Headers.Should().NotContainKey("Custom-Header");
+    }
+    [Test]
+    public async Task HttpRequest_WithAsyncPolicySelector_CanUseSelectorThatReturnsAsynchronously()
+    {
+        var policyName = "custom";
+        // Arrange
+        var hostBuilder = new WebHostBuilder().ConfigureServices(s =>
+        {
+            s.AddRouting();
+            s.AddSecurityHeaderPolicies()
+                .AddPolicy(policyName, p => p.AddCustomHeader("Custom-Header", "MyValue"))
+                .SetPolicySelectorAsync(async ctx =>
+                {
+                    await Task.Yield();
+                    return ctx.SelectedPolicy.Copy().AddCustomHeader("Added-Header", "MyValue");
+                });
+        }).Configure(app =>
+        {
+            app.UseSecurityHeaders();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapPut("/", async context =>
+                {
+                    context.Response.ContentType = "text/html";
+                    await context.Response.WriteAsync("Test response");
+                });
+            });
+        });
+
+        using var server = new TestServer(hostBuilder);
+
+        // Act
+        // Actual request.
+        var response = await server.CreateRequest("/").SendAsync("PUT");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
+        response.Headers.AssertHttpRequestDefaultSecurityHeaders();
+        response.Headers.Should().ContainKey("Added-Header");
+        response.Headers.Should().NotContainKey("Custom-Header");
+    }
+
+    [Test]
     public async Task HttpRequest_WithCustomDefaultPolicy_WhenItReturnsNull_ThrowsInvalidOperationException()
     {
         // Arrange
@@ -527,6 +609,30 @@ public class SecurityHeadersMiddlewareTests
             var act = async () => await server.CreateRequest("/").SendAsync("PUT");
             await act.Should().ThrowAsync<InvalidOperationException>();
         }
+    }
+
+    [Test]
+    public async Task HttpRequest_WithCustomDefaultPolicyAsync_WhenItReturnsNull_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var hostBuilder = new WebHostBuilder()
+            .ConfigureServices(s => s
+                .AddSecurityHeaderPolicies()
+                .SetPolicySelectorAsync(ctx => new(result: null!)))
+            .Configure(app =>
+            {
+                app.UseSecurityHeaders();
+                app.Run(async context =>
+                {
+                    context.Response.ContentType = "text/html";
+                    await context.Response.WriteAsync("Test response");
+                });
+            });
+
+        using var server = new TestServer(hostBuilder);
+        // Act
+        var act = async () => await server.CreateRequest("/").SendAsync("PUT");
+        await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
     [Test]


### PR DESCRIPTION
Alternative approach to #270 to allow users to execute async delegates when selecting a policy.

I implemented using `ValueTask<T>` given that all existing users will be doing sync-only calls, and we shouldn't in general be doing too much heavy work here given that it's in the request hot path.

WDYT @jchannon? A couple of minor questions I still have 

- Is `ValueTask<T>` the right choice here? I think the justification is sound in general, but without measuring it's hard to know whether it's worth the complexity, given we can still use `Task.FromResult()` and avoid the async machinery in both cases🤔 
- Should it be `SetPolicySelectorAsync` or `SetAsyncPolicySelector`🤔  The former reads and groups better with the existing but kind of implies it's the "Set" that's async. 🤷‍♂️ 

