### PR TITLE
Add InsecureHttp and InsecureWs options

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders.Analyzers/InsecureApiAnalyzer.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders.Analyzers/InsecureApiAnalyzer.cs
@@ -1,0 +1,84 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace NetEscapades.AspNetCore.SecurityHeaders.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class InsecureApiAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "NEASPSH002";
+    public static readonly DiagnosticDescriptor Rule = new(
+#pragma warning disable RS2008 // Enable Analyzer Release Tracking
+        id: DiagnosticId,
+#pragma warning restore RS2008
+        title: "API is insecure",
+        messageFormat: "This API is insecure and should not be used in production. {0}{1}.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationStartContext =>
+        {
+            var deprecatedAttributeSymbol = compilationStartContext.Compilation.GetTypeByMetadataName(
+                "NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApiAttribute");
+            if (deprecatedAttributeSymbol is null)
+            {
+                return;
+            }
+
+            // Invocation of methods (including extension methods)
+            // can extend to more operations if necessary 
+            compilationStartContext.RegisterOperationAction(operationContext =>
+            {
+                var invocation = (IInvocationOperation)operationContext.Operation;
+                var symbol = invocation.TargetMethod;
+                if (TryGetDeprecatedData(symbol, deprecatedAttributeSymbol, out var message, out var url))
+                {
+                    var suffix = string.IsNullOrEmpty(url) ? string.Empty : $" See: {url}";
+                    operationContext.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), message, suffix));
+                }
+            }, OperationKind.Invocation);
+        });
+    }
+
+    private static bool TryGetDeprecatedData(ISymbol symbol, INamedTypeSymbol deprecatedAttributeSymbol, out string message, out string url)
+    {
+        message = string.Empty;
+        url = string.Empty;
+
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, deprecatedAttributeSymbol))
+            {
+                // Constructor argument 0 is the Message string
+                if (!attribute.ConstructorArguments.IsDefaultOrEmpty && attribute.ConstructorArguments[0].Value is string m)
+                {
+                    message = m;
+                }
+
+                // Optional named argument Url
+                foreach (var namedArg in attribute.NamedArguments)
+                {
+                    if (namedArg is { Key: "Url", Value.Value: string u })
+                    {
+                        url = u;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.BaseUriDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.BaseUriDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class BaseUriDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public BaseUriDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public BaseUriDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class BaseUriDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public BaseUriDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public BaseUriDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public BaseUriDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class BaseUriDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public BaseUriDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public BaseUriDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public BaseUriDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ChildSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ChildSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class ChildSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ChildSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ChildSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class ChildSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ChildSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ChildSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ChildSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class ChildSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ChildSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public ChildSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public ChildSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ConnectSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ConnectSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class ConnectSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ConnectSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ConnectSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class ConnectSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ConnectSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ConnectSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ConnectSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class ConnectSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ConnectSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public ConnectSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public ConnectSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class CustomDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public CustomDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public CustomDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class CustomDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public CustomDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public CustomDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public CustomDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class CustomDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public CustomDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public CustomDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public CustomDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class DefaultSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public DefaultSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public DefaultSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class DefaultSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public DefaultSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public DefaultSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public DefaultSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class DefaultSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public DefaultSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public DefaultSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public DefaultSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FontSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FontSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class FontSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public FontSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public FontSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class FontSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public FontSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public FontSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public FontSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class FontSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public FontSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public FontSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public FontSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FormActionDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FormActionDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class FormActionDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public FormActionDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public FormActionDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class FormActionDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public FormActionDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public FormActionDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public FormActionDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class FormActionDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public FormActionDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public FormActionDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public FormActionDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class FrameAncestorsDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public FrameAncestorsDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public FrameAncestorsDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class FrameAncestorsDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public FrameAncestorsDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public FrameAncestorsDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public FrameAncestorsDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class FrameAncestorsDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public FrameAncestorsDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public FrameAncestorsDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public FrameAncestorsDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class FrameSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public FrameSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public FrameSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class FrameSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public FrameSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public FrameSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public FrameSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class FrameSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public FrameSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public FrameSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public FrameSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ImageSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ImageSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class ImageSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ImageSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ImageSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class ImageSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ImageSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ImageSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ImageSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class ImageSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ImageSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public ImageSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public ImageSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ManifestSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ManifestSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class ManifestSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ManifestSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ManifestSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class ManifestSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ManifestSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ManifestSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ManifestSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class ManifestSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ManifestSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public ManifestSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public ManifestSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.MediaSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.MediaSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class MediaSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public MediaSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public MediaSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class MediaSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public MediaSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public MediaSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public MediaSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class MediaSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public MediaSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public MediaSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public MediaSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ObjectSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ObjectSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class ObjectSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ObjectSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ObjectSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class ObjectSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ObjectSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ObjectSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ObjectSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class ObjectSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ObjectSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public ObjectSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public ObjectSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class ScriptSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ScriptSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ScriptSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class ScriptSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ScriptSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ScriptSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ScriptSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class ScriptSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ScriptSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public ScriptSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public ScriptSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceElemDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceElemDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class ScriptSourceElemDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ScriptSourceElemDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public ScriptSourceElemDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class ScriptSourceElemDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ScriptSourceElemDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public ScriptSourceElemDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ScriptSourceElemDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class ScriptSourceElemDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public ScriptSourceElemDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public ScriptSourceElemDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public ScriptSourceElemDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class StyleSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public StyleSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public StyleSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class StyleSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public StyleSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public StyleSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public StyleSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class StyleSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public StyleSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public StyleSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public StyleSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class StyleSourceElemDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public StyleSourceElemDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public StyleSourceElemDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class StyleSourceElemDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public StyleSourceElemDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public StyleSourceElemDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public StyleSourceElemDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class StyleSourceElemDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public StyleSourceElemDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public StyleSourceElemDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public StyleSourceElemDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.WorkerSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.WorkerSourceDirectiveBuilder.g.cs
@@ -34,27 +34,6 @@ public partial class WorkerSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public WorkerSourceDirectiveBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public WorkerSourceDirectiveBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class WorkerSourceDirectiveBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public WorkerSourceDirectiveBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public WorkerSourceDirectiveBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public WorkerSourceDirectiveBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class WorkerSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public WorkerSourceDirectiveBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public WorkerSourceDirectiveBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public WorkerSourceDirectiveBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Helpers/InsecureApiAttribute.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Helpers/InsecureApiAttribute.cs
@@ -1,0 +1,32 @@
+using System;
+
+// Keep it block scoped to make it easier to use in tests
+namespace NetEscapades.AspNetCore.SecurityHeaders.Helpers
+{
+    /// <summary>
+    /// Indicates that a given method is insecure. This may be due to library changes or
+    /// changes in the web platform. The type or method may be removed at a later point
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    internal class InsecureApiAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InsecureApiAttribute"/> class.
+        /// </summary>
+        /// <param name="message">A description of why this API is insecure</param>
+        public InsecureApiAttribute(string message)
+        {
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets a description of why this API is insecure
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets a Uri where you can read more why the API is insecure
+        /// </summary>
+        public string? Url { get; } = null;
+    }
+}

--- a/src/SourceGenerator/SourceGenerationHelper.cs
+++ b/src/SourceGenerator/SourceGenerationHelper.cs
@@ -63,27 +63,6 @@ internal static class SourceGenerationHelper
                 $$"""
 
                       /// <summary>
-                      /// Allows blob: URIs to be used as a content source
-                      /// </summary>
-                      /// <returns>The CSP builder for method chaining</returns>
-                      public {{toGenerate.ClassName}} Blob()
-                      {
-                          Sources.Add("blob:");
-                          return this;
-                      }
-
-                      /// <summary>
-                      /// data: Allows data: URIs to be used as a content source.
-                      /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-                      /// </summary>
-                      /// <returns>The CSP builder for method chaining</returns>
-                      public {{toGenerate.ClassName}} Data()
-                      {
-                          Sources.Add("data:");
-                          return this;
-                      }
-
-                      /// <summary>
                       /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
                       /// </summary>
                       /// <param name="uri">The URI to allow.</param>
@@ -126,9 +105,29 @@ internal static class SourceGenerationHelper
             sb.AppendLine(
                 //lang=csharp
                 $$"""
+                      /// <summary>
+                      /// Allows blob: URIs to be used as a content source
+                      /// </summary>
+                      /// <returns>The CSP builder for method chaining</returns>
+                      public {{toGenerate.ClassName}} Blob()
+                      {
+                          Sources.Add("blob:");
+                          return this;
+                      }
 
                       /// <summary>
-                      /// Allow resources served over https
+                      /// data: Allows data: URIs to be used as a content source.
+                      /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+                      /// </summary>
+                      /// <returns>The CSP builder for method chaining</returns>
+                      public {{toGenerate.ClassName}} Data()
+                      {
+                          Sources.Add("data:");
+                          return this;
+                      }
+                  
+                      /// <summary>
+                      /// Allow resources served over https:
                       /// </summary>
                       /// <returns>The CSP builder for method chaining</returns>
                       public {{toGenerate.ClassName}} OverHttps()
@@ -138,12 +137,34 @@ internal static class SourceGenerationHelper
                       }
 
                       /// <summary>
-                      /// Allow resources served over wss
+                      /// Allow resources served over wss:
                       /// </summary>
                       /// <returns>The CSP builder for method chaining</returns>
                       public {{toGenerate.ClassName}} OverWss()
                       {
                           Sources.Add("wss:");
+                          return this;
+                      }
+
+                      /// <summary>
+                      /// Allow resources served over http: This also allows resources served over https://  
+                      /// </summary>
+                      /// <returns>The CSP builder for method chaining</returns>
+                      [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+                      public {{toGenerate.ClassName}} OverInsecureHttp()
+                      {
+                          Sources.Add("http:");
+                          return this;
+                      }
+                  
+                      /// <summary>
+                      /// Allow resources served over ws:This also allows resources served over wss://
+                      /// </summary>
+                      /// <returns>The CSP builder for method chaining</returns>
+                      [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+                      public {{toGenerate.ClassName}} OverInsecureWs()
+                      {
+                          Sources.Add("ws:");
                           return this;
                       }
                   """);

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/.editorconfig
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/.editorconfig
@@ -2,3 +2,4 @@
 [*.{cs,vb}]
 
 dotnet_diagnostic.NEASPSH001.severity = warning
+dotnet_diagnostic.NEASPSH002.severity = warning

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/CspBuilderTests.cs
@@ -242,12 +242,14 @@ public class CspBuilderTests
     }
 
     [Test]
+    [SuppressMessage("Usage", "NEASPSH002:API is insecure")] // insecure http / insecure ws
     public void Build_AddBaseUri_WhenAddsMultipleValue_ReturnsAllValues()
     {
         var builder = new CspBuilder();
-        builder.AddBaseUri().Self().Blob().Data().From("http://testUrl.com");
+        builder.AddBaseUri().Self().Blob().Data().From("http://testUrl.com")
+            .OverInsecureHttp().OverInsecureWs();
         var result = builder.Build();
-        result.ConstantValue.Should().Be("base-uri 'self' blob: data: http://testUrl.com");
+        result.ConstantValue.Should().Be("base-uri 'self' blob: data: http://testUrl.com http: ws:");
     }
 
     [Test]

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -304,6 +304,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.BaseUriDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.BaseUriDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.BaseUriDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.BaseUriDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.BaseUriDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.BaseUriDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.BaseUriDirectiveBuilder Self() { }
     }
@@ -320,6 +322,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ChildSourceDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ChildSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ChildSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ChildSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ChildSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ChildSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ChildSourceDirectiveBuilder Self() { }
     }
@@ -332,6 +336,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ConnectSourceDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ConnectSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ConnectSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ConnectSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ConnectSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ConnectSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ConnectSourceDirectiveBuilder Self() { }
     }
@@ -361,6 +367,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder InlineSpeculationRules() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder ReportSample() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder Self() { }
@@ -386,6 +394,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder InlineSpeculationRules() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder ReportSample() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder Self() { }
@@ -410,6 +420,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FontSourceDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FontSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FontSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FontSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FontSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FontSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FontSourceDirectiveBuilder Self() { }
     }
@@ -422,6 +434,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FormActionDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FormActionDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FormActionDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FormActionDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FormActionDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FormActionDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FormActionDirectiveBuilder Self() { }
     }
@@ -436,6 +450,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameAncestorsDirectiveBuilder Self() { }
     }
@@ -448,6 +464,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.FrameSourceDirectiveBuilder Self() { }
     }
@@ -460,6 +478,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ImageSourceDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ImageSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ImageSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ImageSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ImageSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ImageSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ImageSourceDirectiveBuilder Self() { }
     }
@@ -472,6 +492,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ManifestSourceDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ManifestSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ManifestSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ManifestSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ManifestSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ManifestSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ManifestSourceDirectiveBuilder Self() { }
     }
@@ -484,6 +506,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.MediaSourceDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.MediaSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.MediaSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.MediaSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.MediaSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.MediaSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.MediaSourceDirectiveBuilder Self() { }
     }
@@ -496,6 +520,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ObjectSourceDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ObjectSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ObjectSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ObjectSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ObjectSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ObjectSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ObjectSourceDirectiveBuilder Self() { }
     }
@@ -555,6 +581,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder InlineSpeculationRules() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder ReportSample() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceDirectiveBuilder Self() { }
@@ -580,6 +608,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceElemDirectiveBuilder InlineSpeculationRules() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceElemDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceElemDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceElemDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceElemDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceElemDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceElemDirectiveBuilder ReportSample() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.ScriptSourceElemDirectiveBuilder Self() { }
@@ -616,6 +646,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder ReportSample() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder Self() { }
@@ -638,6 +670,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder ReportSample() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder Self() { }
@@ -672,6 +706,8 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.WorkerSourceDirectiveBuilder From(string uri) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.WorkerSourceDirectiveBuilder None() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.WorkerSourceDirectiveBuilder OverHttps() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.WorkerSourceDirectiveBuilder OverInsecureHttp() { }
+        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.WorkerSourceDirectiveBuilder OverInsecureWs() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.WorkerSourceDirectiveBuilder OverWss() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.WorkerSourceDirectiveBuilder Self() { }
     }

--- a/test/SourceGenerator.Test/ContentSecurityPolicyGeneratorTests.cs
+++ b/test/SourceGenerator.Test/ContentSecurityPolicyGeneratorTests.cs
@@ -20,22 +20,23 @@ public class ContentSecurityPolicyGeneratorTests
     }
 
     [Test]
-    public Task CanGenerateEnumExtensionsInGlobalNamespace()
+    public Task CanGenerateCspMixinsInGlobalNamespace()
     {
-        const string input =
-            $$"""
-            using System;
-            using System.Collections.Generic;
+        var input = $$"""
+                      using System;
+                      using System.Collections.Generic;
+                      
+                      #nullable enable
 
-            namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
-            {
-                [CspMixin(MixinTypes.All)]
-                public partial class TestBuilder : CspDirectiveBuilder
-                {
-                }
-            }
-            {{Included.CspDirectiveBuilder}}
-            """;
+                      namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
+                      {
+                          [CspMixin(MixinTypes.All)]
+                          public partial class TestBuilder : CspDirectiveBuilder
+                          {
+                          }
+                      }
+                      {{Included.CspDirectiveBuilder}}
+                      """;
         var (diagnostics, output) = TestHelpers.GetGeneratedOutput(_generator,
             new(TestHelpers.EmbeddedAttribute, TestHelpers.EmbeddedEnum, input));
 
@@ -45,34 +46,36 @@ public class ContentSecurityPolicyGeneratorTests
 
     private class Included
     {
-        public const string CspDirectiveBuilder =
-            """
-            namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
-            {
-                using Microsoft.AspNetCore.Http;
-                public class CspDirectiveBuilder
-                {
-                    public bool BlockResources { get; set; }
-                    public bool MustReportSample { get; set; }
-                    public List<string> Sources { get; } = new();
-                    public SourceBuilderCollection SourceBuilders { get; } = new();
-                }
-                
-                public class SourceBuilderCollection
-                {
-                    public void Add(Func<HttpContext, string> a, string b)
-                    {
-                    }
-                }
-            }
-            namespace Microsoft.AspNetCore.Http
-            {
-                public class HttpContext
-                {
-                    public string GetNonce() => string.Empty;
-                    public string[] GetScriptCSPHashes() => new string[] { };
-                }
-            }
-            """;
+        public static readonly string CspDirectiveBuilder =
+            $$"""
+              namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
+              {
+                  using Microsoft.AspNetCore.Http;
+                  public class CspDirectiveBuilder
+                  {
+                      public bool BlockResources { get; set; }
+                      public bool MustReportSample { get; set; }
+                      public List<string> Sources { get; } = new();
+                      public SourceBuilderCollection SourceBuilders { get; } = new();
+                  }
+                  
+                  public class SourceBuilderCollection
+                  {
+                      public void Add(Func<HttpContext, string> a, string b)
+                      {
+                      }
+                  }
+              }
+              namespace Microsoft.AspNetCore.Http
+              {
+                  public class HttpContext
+                  {
+                      public string GetNonce() => string.Empty;
+                      public string[] GetScriptCSPHashes() => new string[] { };
+                  }
+              }
+
+              //{{TestHelpers.InsecureApiAttribute}}
+              """;
     }
 }

--- a/test/SourceGenerator.Test/InsecureApiAnalyzerTests.cs
+++ b/test/SourceGenerator.Test/InsecureApiAnalyzerTests.cs
@@ -1,0 +1,109 @@
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NetEscapades.AspNetCore.SecurityHeaders.Analyzers;
+
+namespace SourceGenerator.Test;
+
+public class InsecureApiAnalyzerTests
+{
+    [Test]
+    public async Task EmptySource()
+    {
+        var test = string.Empty;
+        await CSharpAnalyzerVerifier<InsecureApiAnalyzer, DefaultVerifier>.VerifyAnalyzerAsync(test);
+    }
+
+    [Test]
+    public async Task UsageOfExtensionMethodWithoutAttribute()
+    {
+        var test = GetTestCode(
+            /* lang=c# */
+            """
+            // library code
+            public static class TestExtensions
+            {
+                public static void TestApp(this MyTest test){}
+            }
+
+            // customer usage
+            public class MyTest()
+            {
+                public void Main()
+                {
+                    var t = new MyTest();
+                    t.TestApp();
+                }
+            }
+            """);
+        await CSharpAnalyzerVerifier<InsecureApiAnalyzer, DefaultVerifier>.VerifyAnalyzerAsync(test);
+    }
+
+    [Test]
+    public async Task UsageOfMethodWithAttribute()
+    {
+        var test = GetTestCode(
+            /* lang=c# */
+            """
+            // library code
+            public static class TestExtensions
+            {
+                [InsecureApi("This is deprecated")]
+                public static void TestApp(){}
+            }
+
+            // customer usage
+            public class MyTest()
+            {
+                public void Main()
+                {
+                    {|NEASPSH002:TestExtensions.TestApp()|};
+                }
+            }
+            """);
+        await CSharpAnalyzerVerifier<InsecureApiAnalyzer, DefaultVerifier>.VerifyAnalyzerAsync(test);
+    }
+
+    [Test]
+    public async Task UsageOfExtensionMethodWithAttribute()
+    {
+        var test = GetTestCode(
+            /* lang=c# */
+            """
+            // library code
+            public static class TestExtensions
+            {
+                [InsecureApi("This is deprecated")]
+                public static void TestApp(this MyTest test){}
+            }
+
+            // customer usage
+            public class MyTest()
+            {
+                public void Main()
+                {
+                    var t = new MyTest();
+                    {|NEASPSH002:t.TestApp()|};
+                }
+            }
+            """);
+        await CSharpAnalyzerVerifier<InsecureApiAnalyzer, DefaultVerifier>.VerifyAnalyzerAsync(test);
+    }
+
+    private static string GetTestCode(string testCode) => $$"""
+                                                            using System;
+                                                            using System.Collections.Generic;
+                                                            using System.Linq;
+                                                            using System.Text;
+                                                            using System.Threading;
+                                                            using System.Threading.Tasks;
+                                                            using System.Diagnostics;
+                                                            using NetEscapades.AspNetCore.SecurityHeaders.Helpers;
+
+                                                            namespace ConsoleApplication1
+                                                            {
+                                                                {{testCode}}
+                                                            }
+
+                                                            //{{TestHelpers.InsecureApiAttribute}}
+                                                            """;
+}

--- a/test/SourceGenerator.Test/Snapshots/ContentSecurityPolicyGeneratorTests.CanGenerateCspMixinsInGlobalNamespace.verified.txt
+++ b/test/SourceGenerator.Test/Snapshots/ContentSecurityPolicyGeneratorTests.CanGenerateCspMixinsInGlobalNamespace.verified.txt
@@ -34,27 +34,6 @@ public partial class TestBuilder
     }
 
     /// <summary>
-    /// Allows blob: URIs to be used as a content source
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public TestBuilder Blob()
-    {
-        Sources.Add("blob:");
-        return this;
-    }
-
-    /// <summary>
-    /// data: Allows data: URIs to be used as a content source.
-    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public TestBuilder Data()
-    {
-        Sources.Add("data:");
-        return this;
-    }
-
-    /// <summary>
     /// Allow resources from the given <paramref name="uri"/>. May be any non-empty value
     /// </summary>
     /// <param name="uri">The URI to allow.</param>
@@ -89,9 +68,29 @@ public partial class TestBuilder
 
         return this;
     }
+    /// <summary>
+    /// Allows blob: URIs to be used as a content source
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public TestBuilder Blob()
+    {
+        Sources.Add("blob:");
+        return this;
+    }
 
     /// <summary>
-    /// Allow resources served over https
+    /// data: Allows data: URIs to be used as a content source.
+    /// WARNING: This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    public TestBuilder Data()
+    {
+        Sources.Add("data:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over https:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public TestBuilder OverHttps()
@@ -101,12 +100,34 @@ public partial class TestBuilder
     }
 
     /// <summary>
-    /// Allow resources served over wss
+    /// Allow resources served over wss:
     /// </summary>
     /// <returns>The CSP builder for method chaining</returns>
     public TestBuilder OverWss()
     {
         Sources.Add("wss:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over http: This also allows resources served over https://  
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure HTTP scheme. Consider calling OverHttps() instead")]
+    public TestBuilder OverInsecureHttp()
+    {
+        Sources.Add("http:");
+        return this;
+    }
+
+    /// <summary>
+    /// Allow resources served over ws:This also allows resources served over wss://
+    /// </summary>
+    /// <returns>The CSP builder for method chaining</returns>
+    [global::NetEscapades.AspNetCore.SecurityHeaders.Helpers.InsecureApi("This API allows the use of the insecure websocket scheme. Consider calling OverWss() instead")]
+    public TestBuilder OverInsecureWs()
+    {
+        Sources.Add("ws:");
         return this;
     }
 

--- a/test/SourceGenerator.Test/SourceGenerator.Test.csproj
+++ b/test/SourceGenerator.Test/SourceGenerator.Test.csproj
@@ -34,6 +34,9 @@
     <EmbeddedResource Include="..\..\src\NetEscapades.AspNetCore.SecurityHeaders\Helpers\DeprecatedAttribute.cs">
       <Link>DeprecatedAttribute.cs</Link>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\..\src\NetEscapades.AspNetCore.SecurityHeaders\Helpers\InsecureApiAttribute.cs">
+      <Link>InsecureApiAttribute.cs</Link>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/test/SourceGenerator.Test/TestHelpers.cs
+++ b/test/SourceGenerator.Test/TestHelpers.cs
@@ -26,6 +26,9 @@ internal static class TestHelpers
     public static string DeprecatedAttribute { get; }
         = LoadEmbeddedResource("SourceGenerator.Test.DeprecatedAttribute.cs");
 
+    public static string InsecureApiAttribute { get; }
+        = LoadEmbeddedResource("SourceGenerator.Test.InsecureApiAttribute.cs");
+
     private static string LoadEmbeddedResource(string resourceName)
     {
         var assembly = typeof(TestHelpers).Assembly;


### PR DESCRIPTION
@tiesont flagged that we need `http:` and `ws:` for browserlink, so added the insecure options too:

- `OverInsecureHttp()`
- `OverInsecureWs()`

To try to discourage their use in general (because they allow insecure usage), added an analyzer to mark them as insecure. That said, it seemed weird to make them Warnings, so just added them as Info, the same as in #272. If you want to be safe, you can always increase the level:

```
dotnet_diagnostic.NEASPSH002.severity = warning
```

Also, small fix, moved the `data:` and `blob:` to the scheme source attribute