### PR TITLE
Fix `StyleSourceDirectiveBuilder.WithHashTagHelper`

### DIFF
--- a/.github/workflows/BuildAndPack.yml
+++ b/.github/workflows/BuildAndPack.yml
@@ -21,7 +21,7 @@ jobs:
           - os: linux
             vm: ubuntu-latest
           - os: macos
-            vm: macos-13  # latest is arm64, and it breaks a bunch of stuff
+            vm: macos-14  # latest is arm64, and it breaks a bunch of stuff
     env:
       MSBuildEnableWorkloadResolver: false
     name: ${{ matrix.os}}

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "disable",
-    "allowPrerelease": true
+    "version": "10.0.101",
+    "allowPrerelease": false
   }
 }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder.g.cs
@@ -179,18 +179,6 @@ public partial class CustomDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow sources for content generated using the HashTagHelper.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public CustomDirectiveBuilder WithHashTagHelper()
-    {
-        SourceBuilders.Add(
-            ctx => string.Join(" ", ctx.GetScriptCSPHashes()),
-            $"NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder.{nameof(WithHashTagHelper)}");
-        return this;
-    }
-
-    /// <summary>
     /// Allows the use of inline resources, such as inline &lt;scripT&gt; elements, javascript : URLs,
     /// inline event handlers, and inline &lt;style&gt; elements
     /// WARNING: This source is insecure - you should not use this directive if at all possible

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder.g.cs
@@ -179,18 +179,6 @@ public partial class DefaultSourceDirectiveBuilder
     }
 
     /// <summary>
-    /// Allow sources for content generated using the HashTagHelper.
-    /// </summary>
-    /// <returns>The CSP builder for method chaining</returns>
-    public DefaultSourceDirectiveBuilder WithHashTagHelper()
-    {
-        SourceBuilders.Add(
-            ctx => string.Join(" ", ctx.GetScriptCSPHashes()),
-            $"NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder.{nameof(WithHashTagHelper)}");
-        return this;
-    }
-
-    /// <summary>
     /// Allows the use of inline resources, such as inline &lt;scripT&gt; elements, javascript : URLs,
     /// inline event handlers, and inline &lt;style&gt; elements
     /// WARNING: This source is insecure - you should not use this directive if at all possible

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceAttrDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceAttrDirectiveBuilder.g.cs
@@ -77,7 +77,7 @@ public partial class StyleSourceAttrDirectiveBuilder
     public StyleSourceAttrDirectiveBuilder WithHashTagHelper()
     {
         SourceBuilders.Add(
-            ctx => string.Join(" ", ctx.GetScriptCSPHashes()),
+            ctx => string.Join(" ", ctx.GetStyleCSPHashes()),
             $"NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceAttrDirectiveBuilder.{nameof(WithHashTagHelper)}");
         return this;
     }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder.g.cs
@@ -185,7 +185,7 @@ public partial class StyleSourceDirectiveBuilder
     public StyleSourceDirectiveBuilder WithHashTagHelper()
     {
         SourceBuilders.Add(
-            ctx => string.Join(" ", ctx.GetScriptCSPHashes()),
+            ctx => string.Join(" ", ctx.GetStyleCSPHashes()),
             $"NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceDirectiveBuilder.{nameof(WithHashTagHelper)}");
         return this;
     }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder.g.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Generated/netcoreapp3.1/SourceGenerator/SourceGenerator.ContentSecurityPolicyGenerator/NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder.g.cs
@@ -185,7 +185,7 @@ public partial class StyleSourceElemDirectiveBuilder
     public StyleSourceElemDirectiveBuilder WithHashTagHelper()
     {
         SourceBuilders.Add(
-            ctx => string.Join(" ", ctx.GetScriptCSPHashes()),
+            ctx => string.Join(" ", ctx.GetStyleCSPHashes()),
             $"NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.StyleSourceElemDirectiveBuilder.{nameof(WithHashTagHelper)}");
         return this;
     }

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/GeneratorHelpers/MixinTypes.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/GeneratorHelpers/MixinTypes.cs
@@ -74,7 +74,17 @@ internal enum MixinTypes
     None = 1 << 12,
 
     /// <summary>
-    /// Convenience combination of all mixin flags.
+    /// Adds the <c>'WithHashTagHelper'</c> source, by calling <c>GetScriptCSPHashes</c>
+    /// </summary>
+    ScriptHashTagHelper = 1 << 13,
+
+    /// <summary>
+    /// Adds the <c>'WithHashTagHelper'</c> source, by calling <c>GetStyleCSPHashes</c>
+    /// </summary>
+    StyleHashTagHelper = 1 << 14,
+
+    /// <summary>
+    /// Convenience combination of all mixin flags except <see cref="ScriptHashTagHelper"/> and <see cref="StyleHashTagHelper"/>
     /// </summary>
     All = Self |
           HostSource |

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceAttrDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceAttrDirectiveBuilder.cs
@@ -9,7 +9,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 /// can be specified for all JavaScript script sources using <c>script-src</c>, or just for
 /// &lt;script&gt; elements using <c>script-src-elem</c>.)
 /// </summary>
-[CspMixin(MixinTypes.UnsafeHashes | MixinTypes.Hash | MixinTypes.UnsafeInline | MixinTypes.None | MixinTypes.ReportSample)]
+[CspMixin(MixinTypes.UnsafeHashes | MixinTypes.Hash | MixinTypes.UnsafeInline | MixinTypes.None | MixinTypes.ReportSample | MixinTypes.ScriptHashTagHelper)]
 public partial class ScriptSourceAttrDirectiveBuilder : CspDirectiveBuilder
 {
     /// <summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceDirectiveBuilder.cs
@@ -5,7 +5,7 @@
 /// This includes not only URLs loaded directly into &lt;script&gt; elements, but also things
 /// like inline script event handlers (onclick) and XSLT stylesheets which can trigger script execution.
 /// </summary>
-[CspMixin(MixinTypes.All)]
+[CspMixin(MixinTypes.All | MixinTypes.ScriptHashTagHelper)]
 public partial class ScriptSourceDirectiveBuilder : CspDirectiveBuilder
 {
     /// <summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceElemDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/ScriptSourceElemDirectiveBuilder.cs
@@ -9,7 +9,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 /// "unsafe-eval" check, and XSLT stylesheets. (Valid sources can be specified for all
 /// JavaScript script sources using <c>script-src</c>, or just for inline script handlers using <c>script-src-attr</c>.)
 /// </summary>
-[CspMixin(MixinTypes.All & ~MixinTypes.UnsafeHashes)] // Everything except unsafe hashes
+[CspMixin((MixinTypes.All & ~MixinTypes.UnsafeHashes) | MixinTypes.ScriptHashTagHelper)] // Everything except unsafe hashes
 public partial class ScriptSourceElemDirectiveBuilder : CspDirectiveBuilder
 {
     /// <summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceAttrDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceAttrDirectiveBuilder.cs
@@ -6,7 +6,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 /// The directive does not set valid sources for &lt;style&gt; elements and &lt;link&gt; elements with rel="stylesheet".
 /// These are set using <c>style-src-elem</c> (and valid sources for all styles may be set with <c>style-src</c>).
 /// </summary>
-[CspMixin(MixinTypes.UnsafeInline | MixinTypes.UnsafeHashes | MixinTypes.Hash | MixinTypes.ReportSample | MixinTypes.None)]
+[CspMixin(MixinTypes.UnsafeInline | MixinTypes.UnsafeHashes | MixinTypes.Hash | MixinTypes.ReportSample | MixinTypes.None | MixinTypes.StyleHashTagHelper)]
 public partial class StyleSourceAttrDirectiveBuilder : CspDirectiveBuilder
 {
     /// <summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceDirectiveBuilder.cs
@@ -4,7 +4,7 @@
 /// The <c>style-src</c> directive specifies valid sources for sources for stylesheets.
 /// </summary>
 [CspMixin(MixinTypes.HostSource | MixinTypes.SchemeSource | MixinTypes.Self | MixinTypes.None | MixinTypes.UnsafeEval
-          | MixinTypes.UnsafeInline | MixinTypes.UnsafeHashes | MixinTypes.Hash | MixinTypes.Nonce | MixinTypes.ReportSample)]
+          | MixinTypes.UnsafeInline | MixinTypes.UnsafeHashes | MixinTypes.Hash | MixinTypes.Nonce | MixinTypes.ReportSample | MixinTypes.StyleHashTagHelper)]
 public partial class StyleSourceDirectiveBuilder : CspDirectiveBuilder
 {
     /// <summary>

--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceElemDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/ContentSecurityPolicy/StyleSourceElemDirectiveBuilder.cs
@@ -8,7 +8,7 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy;
 /// set using <c>style-src-attr</c> (and valid sources for all styles may be set with <c>style-src</c>).
 /// </summary>
 [CspMixin(MixinTypes.HostSource | MixinTypes.SchemeSource | MixinTypes.Self | MixinTypes.None | MixinTypes.UnsafeEval
-          | MixinTypes.UnsafeInline | MixinTypes.Hash | MixinTypes.Nonce | MixinTypes.ReportSample)]
+          | MixinTypes.UnsafeInline | MixinTypes.Hash | MixinTypes.Nonce | MixinTypes.ReportSample | MixinTypes.StyleHashTagHelper)]
 public partial class StyleSourceElemDirectiveBuilder : CspDirectiveBuilder
 {
     /// <summary>

--- a/src/SourceGenerator/SourceGenerationHelper.cs
+++ b/src/SourceGenerator/SourceGenerationHelper.cs
@@ -221,7 +221,14 @@ internal static class SourceGenerationHelper
                       {
                           return WithHash("sha512", hash);
                       }
-                  
+                  """);
+        }
+
+        if (Contains(mixins, MixinTypes.ScriptHashTagHelper))
+        {
+            sb.AppendLine(
+                $$"""
+
                       /// <summary>
                       /// Allow sources for content generated using the HashTagHelper.
                       /// </summary>
@@ -230,6 +237,25 @@ internal static class SourceGenerationHelper
                       {
                           SourceBuilders.Add(
                               ctx => string.Join(" ", ctx.GetScriptCSPHashes()),
+                              $"{{toGenerate.NameSpace}}.{{toGenerate.ClassName}}.{nameof(WithHashTagHelper)}");
+                          return this;
+                      }
+                  """);
+        }
+
+        if (Contains(mixins, MixinTypes.StyleHashTagHelper))
+        {
+            sb.AppendLine(
+                $$"""
+
+                      /// <summary>
+                      /// Allow sources for content generated using the HashTagHelper.
+                      /// </summary>
+                      /// <returns>The CSP builder for method chaining</returns>
+                      public {{toGenerate.ClassName}} WithHashTagHelper()
+                      {
+                          SourceBuilders.Add(
+                              ctx => string.Join(" ", ctx.GetStyleCSPHashes()),
                               $"{{toGenerate.NameSpace}}.{{toGenerate.ClassName}}.{nameof(WithHashTagHelper)}");
                           return this;
                       }

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PublicApiTest.PublicApiHasNotChanged.verified.txt
@@ -381,7 +381,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder WithHash256(string hash) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder WithHashSha384(string hash) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder WithHashSha512(string hash) { }
-        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder WithHashTagHelper() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CustomDirectiveBuilder WithNonce() { }
     }
     public class DefaultSourceDirectiveBuilder : NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CspDirectiveBuilder
@@ -408,7 +407,6 @@ namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder WithHash256(string hash) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder WithHashSha384(string hash) { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder WithHashSha512(string hash) { }
-        public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder WithHashTagHelper() { }
         public NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.DefaultSourceDirectiveBuilder WithNonce() { }
     }
     public class FontSourceDirectiveBuilder : NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy.CspDirectiveBuilder

--- a/test/SourceGenerator.Test/ContentSecurityPolicyGeneratorTests.cs
+++ b/test/SourceGenerator.Test/ContentSecurityPolicyGeneratorTests.cs
@@ -30,7 +30,7 @@ public class ContentSecurityPolicyGeneratorTests
 
                       namespace NetEscapades.AspNetCore.SecurityHeaders.Headers.ContentSecurityPolicy
                       {
-                          [CspMixin(MixinTypes.All)]
+                          [CspMixin(MixinTypes.All | MixinTypes.ScriptHashTagHelper)]
                           public partial class TestBuilder : CspDirectiveBuilder
                           {
                           }


### PR DESCRIPTION
#272 updated to use a source generator to generate methods, but there were a few bugs with it:

- It was incorrectly using `GetScriptCSPHashes()` inside `WithHashTagHelper()` in style-source directives
- It added `WithHashTagHelper` to the default and custom directive builders

This PR fixes the former by calling `GetStyleCSPHashes` instead where appropriate.

It also (controversially perhaps 🙈) removes the `WithHashTagHelper()` as I consider adding those to be a bug, as they don't really make sense to be exposed there

Fixes #278 