### PR TITLE
Update Permissions-Policy format to use parentheses

### DIFF
--- a/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyDirectiveBuilder.cs
+++ b/src/NetEscapades.AspNetCore.SecurityHeaders/Headers/PermissionsPolicy/PermissionsPolicyDirectiveBuilder.cs
@@ -47,11 +47,6 @@ public abstract class PermissionsPolicyDirectiveBuilder : PermissionsPolicyDirec
             return $"{Directive}=*";
         }
 
-        if (Sources.Count == 1)
-        {
-            return $"{Directive}={Sources.FirstOrDefault()}";
-        }
-
         return $"{Directive}=({string.Join(" ", Sources)})";
     }
 

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PermissionsPolicyBuilderTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/PermissionsPolicyBuilderTests.cs
@@ -20,7 +20,7 @@ public class PermissionsPolicyBuilderTests
         var builder = new PermissionsPolicyBuilder();
         builder.AddAccelerometer().Self();
         var result = builder.Build();
-        result.Should().Be("accelerometer=self");
+        result.Should().Be("accelerometer=(self)");
     }
 
     [Test]

--- a/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
+++ b/test/NetEscapades.AspNetCore.SecurityHeaders.Test/SecurityHeadersMiddlewareTests.cs
@@ -1425,7 +1425,7 @@ public class SecurityHeadersMiddlewareTests
         response.EnsureSuccessStatusCode();
         (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
         response.Headers.Should().ContainKey("Permissions-Policy").WhoseValue.Should().ContainSingle(
-            "accelerometer=(self \"https://testurl1.com\" \"https://testurl2.com\" \"https://testurl3.com\" \"https://testurl4.com\"), fullscreen=self, ambient-light-sensor=\"https://testurl.com\", geolocation=(), camera=*\"");
+            "accelerometer=(self \"https://testurl1.com\" \"https://testurl2.com\" \"https://testurl3.com\" \"https://testurl4.com\"), fullscreen=(self), ambient-light-sensor=(\"https://testurl.com\"), geolocation=(), camera=*\"");
     }
 
     [Test]
@@ -1459,7 +1459,7 @@ public class SecurityHeadersMiddlewareTests
         response.EnsureSuccessStatusCode();
         (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
         response.Headers.Should().ContainKey("Permissions-Policy").WhoseValue.Should().ContainSingle(
-            "accelerometer=(self \"https://testurl1.com\" \"https://testurl2.com\" \"https://testurl3.com\" \"https://testurl4.com\"), fullscreen=self, ambient-light-sensor=\"https://testurl.com\", geolocation=(), camera=*\"");
+            "accelerometer=(self \"https://testurl1.com\" \"https://testurl2.com\" \"https://testurl3.com\" \"https://testurl4.com\"), fullscreen=(self), ambient-light-sensor=(\"https://testurl.com\"), geolocation=(), camera=*\"");
     }
 
     [Test]
@@ -1490,7 +1490,7 @@ public class SecurityHeadersMiddlewareTests
         (await response.Content.ReadAsStringAsync()).Should().Be("Test response");
         var header = response.Headers.GetValues("Permissions-Policy").FirstOrDefault();
         header.Should().NotBeNull();
-        header.Should().Be("fullscreen=self, geolocation=()");
+        header.Should().Be("fullscreen=(self), geolocation=()");
     }
 
     [Test]


### PR DESCRIPTION
Revise the Permissions-Policy directive format to ensure consistency by using parentheses for sources. Update tests to reflect these changes.

Fixes #285